### PR TITLE
improve local ice candidate gathering

### DIFF
--- a/packages/ice/src/ice.ts
+++ b/packages/ice/src/ice.ts
@@ -6,10 +6,11 @@ import * as nodeIp from "ip";
 import range from "lodash/range";
 import isEqual from "lodash/isEqual";
 import { isIPv4 } from "net";
-import PCancelable from "p-cancelable";
+import PCancelable, { all } from "p-cancelable";
 import { Event } from "rx.mini";
 import timers from "timers/promises";
 import util from "util";
+import os from "os";
 
 import { Candidate, candidateFoundation, candidatePriority } from "./candidate";
 import { TransactionError } from "./exceptions";
@@ -82,7 +83,7 @@ export class Connection {
       this.localCandidatesStart = true;
       this.promiseGatherCandidates = new Event();
 
-      const address = getHostAddress(this.useIpv4, this.useIpv6);
+      const address = getHostAddresses(this.useIpv4, this.useIpv6);
       for (const component of this._components) {
         const candidates = await this.getComponentCandidates(
           component,
@@ -976,10 +977,39 @@ export function candidatePairPriority(
   return (1 << 32) * Math.min(G, D) + 2 * Math.max(G, D) + (G > D ? 1 : 0);
 }
 
-export function getHostAddress(useIpv4: boolean, useIpv6: boolean) {
+function nodeIpAddress(family: string): string[] {
+  // https://chromium.googlesource.com/external/webrtc/+/master/rtc_base/network.cc#236
+  const costlyNetworks = ['ipsec', 'tun', 'utun', 'tap'];
+
+  const interfaces = os.networkInterfaces();
+
+  const all = Object.keys(interfaces).map(nic => {
+    for (const costly of costlyNetworks) {
+      if (nic.startsWith(costly)) {
+        return {
+          nic,
+          addresses: [],
+        }
+      }
+    }
+    const addresses = interfaces[nic]!.filter(details => details.family.toLowerCase() === family && !nodeIp.isLoopback(details.address));
+    return {
+      nic,
+      addresses: addresses.map(address => address.address),
+    }
+  }).filter(address => !!address);
+
+  // os.networkInterfaces doesn't actually return addresses in a good order.
+  // have seen instances where en0 (ethernet) is after en1 (wlan), etc.
+  // eth0 > eth1
+  all.sort((a, b) => a.nic.localeCompare(b.nic));
+  return Object.values(all).map(entry => entry.addresses).flat();
+}
+
+export function getHostAddresses(useIpv4: boolean, useIpv6: boolean) {
   const address: string[] = [];
-  if (useIpv4) address.push(nodeIp.address("", "ipv4"));
-  if (useIpv6) address.push(nodeIp.address("", "ipv6"));
+  if (useIpv4) address.push(...nodeIpAddress("ipv4"));
+  if (useIpv6) address.push(...nodeIpAddress("ipv6"));
   return address;
 }
 


### PR DESCRIPTION
gather all network addresses, and not just the first.
sort the interfaces similar to chrome, and don't simply use the
order it is returned.