### PR TITLE
fix reference to dtlsTransport used by transceiver

### DIFF
--- a/packages/webrtc/src/media/rtpTransceiver.ts
+++ b/packages/webrtc/src/media/rtpTransceiver.ts
@@ -39,13 +39,17 @@ export class RTCRtpTransceiver {
 
   constructor(
     public readonly kind: Kind,
-    public dtlsTransport: RTCDtlsTransport,
+    dtlsTransport: RTCDtlsTransport,
     public receiver: RTCRtpReceiver,
     public sender: RTCRtpSender,
     /**RFC 8829 4.2.4.  direction the transceiver was initialized with */
     public direction: Direction
   ) {
     this.setDtlsTransport(dtlsTransport);
+  }
+
+  get dtlsTransport() {
+    return this.receiver.dtlsTransport;
   }
 
   setDtlsTransport(dtls: RTCDtlsTransport) {


### PR DESCRIPTION
when setDtlsTransport is called, the internal dtstransport should be updated, but it is not, causing a mismatch between transceiver and sender/receiver. it is probably best to simply refer to the instance in receiver/sender. alternatively, the property could be updated, up to you.
confirmed this fixes my issues with bundle/non-bundle connection state.