### PR TITLE
stop scheduling checks if the IceState is closed.

### DIFF
--- a/packages/ice/src/ice.ts
+++ b/packages/ice/src/ice.ts
@@ -242,6 +242,7 @@ export class Connection {
     // # perform checks
     // 5.8.  Scheduling Checks
     for (;;) {
+      if (this.state === 'closed') break;
       if (!this.schedulingChecks()) break;
       await timers.setTimeout(20);
     }


### PR DESCRIPTION
This allows the connection to clean up if it's closed without ever completing (error or success).