### PR TITLE
improve dns.lookup uv thread pool exhaustion

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -7,6 +7,7 @@ on:
       - develop
       - "feature/*"
       - "maintain/*"
+      - "pr/*"
   pull_request:
     types: [opened]
     branches: [develop]

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -7,7 +7,6 @@ on:
       - develop
       - "feature/*"
       - "maintain/*"
-      - "pr/*"
   pull_request:
     types: [opened]
     branches: [develop]

--- a/packages/ice/src/dns/lookup.ts
+++ b/packages/ice/src/dns/lookup.ts
@@ -17,18 +17,19 @@ export class DnsLookup {
   constructor() {
     const lookupWorkerFunction = () => {
       const worker_thread = global.require("worker_threads");
-      const { lookup } = global.require('dns');
+      const { lookup } = global.require("dns");
 
-      const dnsLookup = (host: string) => lookup(host, (err: Error, address: string, family: number) => {
-        worker_thread.parentPort!.postMessage({
-          err: err?.message,
-          address,
-          family,
-        } as DnsLookupResult);
-        process.exit();
-      });
+      const dnsLookup = (host: string) =>
+        lookup(host, (err: Error, address: string, family: number) => {
+          worker_thread.parentPort!.postMessage({
+            err: err?.message,
+            address,
+            family,
+          } as DnsLookupResult);
+          process.exit();
+        });
 
-      worker_thread.parentPort!.on('message', (message: DnsLookupRequest) => {
+      worker_thread.parentPort!.on("message", (message: DnsLookupRequest) => {
         const { host } = message;
         dnsLookup(host);
       });
@@ -49,23 +50,24 @@ export class DnsLookup {
       return cached;
     }
     cached = new Promise((r, f) => {
-      const exitListener = (exitCode: number) => f(new Error(`dns.lookup thread exited unexpectedly: ${exitCode}`));
+      const exitListener = (exitCode: number) =>
+        f(new Error(`dns.lookup thread exited unexpectedly: ${exitCode}`));
 
       const threadMessageListener = (result: DnsLookupResult) => {
         if (result.host !== host) {
           return;
         }
 
-        this.thread.removeListener('message', threadMessageListener);
-        this.thread.removeListener('exit', exitListener);
+        this.thread.removeListener("message", threadMessageListener);
+        this.thread.removeListener("exit", exitListener);
 
         if (!result.address)
-          return f(new Error(result.err || 'dns.lookup thread unknown error'));
+          return f(new Error(result.err || "dns.lookup thread unknown error"));
         r(result.address);
       };
 
-      this.thread.on('message', threadMessageListener);
-      this.thread.on('exit', exitListener);
+      this.thread.on("message", threadMessageListener);
+      this.thread.on("exit", exitListener);
 
       this.thread.postMessage({
         host,

--- a/packages/ice/src/dns/lookup.ts
+++ b/packages/ice/src/dns/lookup.ts
@@ -25,6 +25,7 @@ export class DnsLookup {
             err: err?.message,
             address,
             family,
+            host,
           } as DnsLookupResult);
           process.exit();
         });

--- a/packages/ice/src/dns/lookup.ts
+++ b/packages/ice/src/dns/lookup.ts
@@ -21,16 +21,17 @@ export class DnsLookup {
 
       const dnsLookup = (host: string) =>
         lookup(host, (err: Error, address: string, family: number) => {
-          worker_thread.parentPort!.postMessage({
+          const res: DnsLookupResult = {
             err: err?.message,
             address,
             family,
             host,
-          } as DnsLookupResult);
+          };
+          worker_thread.parentPort?.postMessage(res);
           process.exit();
         });
 
-      worker_thread.parentPort!.on("message", (message: DnsLookupRequest) => {
+      worker_thread.parentPort?.on("message", (message: DnsLookupRequest) => {
         const { host } = message;
         dnsLookup(host);
       });

--- a/packages/ice/src/dns/lookup.ts
+++ b/packages/ice/src/dns/lookup.ts
@@ -1,46 +1,82 @@
-import dns from "dns";
-import { setTimeout } from "timers/promises";
-import util from "util";
+import worker_thread from "worker_threads";
 
-import { PromiseQueue } from "../../../common/src";
-
-class DnsLookup {
-  private queue = new PromiseQueue();
-  private requesting = false;
-  private cache: { [local: string]: string } = {};
-
-  async lookup(host: string) {
-    return this.queue.push(() => this.task(host));
-  }
-
-  private async task(host: string) {
-    if (this.cache[host]) {
-      return this.cache[host];
-    }
-
-    try {
-      if (this.requesting) {
-        throw undefined;
-      }
-
-      this.requesting = true;
-      const promise = util.promisify(dns.lookup)(host);
-      promise
-        .then(() => {
-          this.requesting = false;
-        })
-        .catch(() => {});
-
-      const res = await Promise.race([promise, setTimeout(200)]);
-      if (!res) {
-        throw undefined;
-      }
-      this.cache[host] = res.address;
-      return res.address;
-    } catch (error) {
-      return "127.0.0.1";
-    }
-  }
+interface DnsLookupRequest {
+  host: string;
 }
 
-export const dnsLookup = new DnsLookup();
+interface DnsLookupResult extends DnsLookupRequest {
+  err?: string;
+  address?: string;
+  family?: number;
+}
+
+export class DnsLookup {
+  thread: worker_thread.Worker;
+  cache = new Map<string, Promise<string>>();
+
+  constructor() {
+    const lookupWorkerFunction = () => {
+      const worker_thread = global.require("worker_threads");
+      const { lookup } = global.require('dns');
+
+      const dnsLookup = (host: string) => lookup(host, (err: Error, address: string, family: number) => {
+        worker_thread.parentPort!.postMessage({
+          err: err?.message,
+          address,
+          family,
+        } as DnsLookupResult);
+        process.exit();
+      });
+
+      worker_thread.parentPort!.on('message', (message: DnsLookupRequest) => {
+        const { host } = message;
+        dnsLookup(host);
+      });
+    };
+
+    const lookupEval = `(${lookupWorkerFunction})()`;
+
+    this.thread = new worker_thread.Worker(lookupEval, {
+      eval: true,
+    });
+
+    this.thread.setMaxListeners(100);
+  }
+
+  async lookup(host: string): Promise<string> {
+    let cached = this.cache.get(host);
+    if (cached) {
+      return cached;
+    }
+    cached = new Promise((r, f) => {
+      const exitListener = (exitCode: number) => f(new Error(`dns.lookup thread exited unexpectedly: ${exitCode}`));
+
+      const threadMessageListener = (result: DnsLookupResult) => {
+        if (result.host !== host) {
+          return;
+        }
+
+        this.thread.removeListener('message', threadMessageListener);
+        this.thread.removeListener('exit', exitListener);
+
+        if (!result.address)
+          return f(new Error(result.err || 'dns.lookup thread unknown error'));
+        r(result.address);
+      };
+
+      this.thread.on('message', threadMessageListener);
+      this.thread.on('exit', exitListener);
+
+      this.thread.postMessage({
+        host,
+      } as DnsLookupRequest);
+    });
+
+    this.cache.set(host, cached);
+    return cached;
+  }
+
+  close() {
+    return this.thread.terminate();
+  }
+}

--- a/packages/ice/src/ice.ts
+++ b/packages/ice/src/ice.ts
@@ -242,7 +242,7 @@ export class Connection {
     // # perform checks
     // 5.8.  Scheduling Checks
     for (;;) {
-      if (this.state === 'closed') break;
+      if (this.state === "closed") break;
       if (!this.schedulingChecks()) break;
       await timers.setTimeout(20);
     }
@@ -446,15 +446,13 @@ export class Connection {
 
     if (remoteCandidate.host.includes(".local")) {
       try {
-        if (this.state === 'closed')
-          return;
+        if (this.state === "closed") return;
         if (!this.dnsLookup) {
           this.dnsLookup = new DnsLookup();
         }
         const host = await this.dnsLookup.lookup(remoteCandidate.host);
         remoteCandidate.host = host;
-      }
-      catch (error) {
+      } catch (error) {
         return;
       }
     }

--- a/packages/ice/src/ice.ts
+++ b/packages/ice/src/ice.ts
@@ -11,7 +11,7 @@ import { Event } from "rx.mini";
 import timers from "timers/promises";
 
 import { Candidate, candidateFoundation, candidatePriority } from "./candidate";
-import { dnsLookup } from "./dns/lookup";
+import { DnsLookup } from "./dns/lookup";
 import { TransactionError } from "./exceptions";
 import { difference, Future, future, PQueue, randomString } from "./helper";
 import { classes, methods } from "./stun/const";
@@ -40,6 +40,7 @@ export class Connection {
   _localCandidatesEnd = false;
   _tieBreaker: BigInt = BigInt(new Uint64BE(randomBytes(64)).toString());
   state: IceState = "new";
+  dnsLookup?: DnsLookup;
 
   readonly onData = new Event<[Buffer, number]>();
   readonly stateChanged = new Event<[IceState]>();
@@ -417,6 +418,8 @@ export class Connection {
 
     this.protocols = [];
     this.localCandidates = [];
+
+    await this.dnsLookup?.close();
   }
 
   private setState(state: IceState) {
@@ -442,8 +445,18 @@ export class Connection {
     }
 
     if (remoteCandidate.host.includes(".local")) {
-      const host = await dnsLookup.lookup(remoteCandidate.host);
-      remoteCandidate.host = host;
+      try {
+        if (this.state === 'closed')
+          return;
+        if (!this.dnsLookup) {
+          this.dnsLookup = new DnsLookup();
+        }
+        const host = await this.dnsLookup.lookup(remoteCandidate.host);
+        remoteCandidate.host = host;
+      }
+      catch (error) {
+        return;
+      }
     }
 
     try {


### PR DESCRIPTION
improve dns.lookup uv thread pool exhaustion by moving onto a separate worker thread with a different pool.

Each connection will get its own uv thread pool (and worker thread/runtime). This will be more overhead per connection if there are `.local` addresses. This also fixes the issue where dns.lookups are indefinitely cached (and may change as the connectivity of the peer changes from cellular to lan), since the cache is now per connection.