### PR TITLE
set eslint config as root

### DIFF
--- a/packages/webrtc/.eslintrc
+++ b/packages/webrtc/.eslintrc
@@ -6,6 +6,7 @@
     "plugin:prettier/recommended",
     "prettier"
   ],
+  "root": true,
   "env": {
     "jest": true,
     "es6": true,


### PR DESCRIPTION
to run werift as submodule, need root setting to eslint configs will not conflict

```sh
Oops! Something went wrong! :(

ESLint: 8.20.0

ESLint couldn't determine the plugin "prettier" uniquely.
```