### PR TITLE
Allow use of specific network interface

### DIFF
--- a/packages/ice/src/ice.ts
+++ b/packages/ice/src/ice.ts
@@ -10,6 +10,7 @@ import PCancelable from "p-cancelable";
 import { Event } from "rx.mini";
 import timers from "timers/promises";
 
+import { InterfaceAddresses } from "../../common/src/network";
 import { Candidate, candidateFoundation, candidatePriority } from "./candidate";
 import { DnsLookup } from "./dns/lookup";
 import { TransactionError } from "./exceptions";
@@ -112,7 +113,11 @@ export class Connection {
     for (const address of addresses) {
       // # create transport
       const protocol = new StunProtocol(this);
-      await protocol.connectionMade(isIPv4(address), this.options.portRange);
+      await protocol.connectionMade(
+        isIPv4(address),
+        this.options.portRange,
+        this.options.interfaceAddresses
+      );
       protocol.localAddress = address;
       this.protocols.push(protocol);
 
@@ -180,7 +185,10 @@ export class Connection {
         this.turnServer,
         this.options.turnUsername,
         this.options.turnPassword,
-        { portRange: this.options.portRange }
+        {
+          portRange: this.options.portRange,
+          interfaceAddresses: this.options.interfaceAddresses,
+        }
       );
       this.protocols.push(protocol);
 
@@ -951,6 +959,7 @@ export interface IceOptions {
   useIpv4: boolean;
   useIpv6: boolean;
   portRange?: [number, number];
+  interfaceAddresses?: InterfaceAddresses;
 }
 
 const defaultOptions: IceOptions = {

--- a/packages/ice/src/stun/protocol.ts
+++ b/packages/ice/src/stun/protocol.ts
@@ -1,6 +1,7 @@
 import debug from "debug";
 import { Event } from "rx.mini";
 
+import { InterfaceAddresses } from "../../../common/src/network";
 import { Candidate } from "../candidate";
 import { Connection } from "../ice";
 import { UdpTransport } from "../transport";
@@ -31,11 +32,23 @@ export class StunProtocol implements Protocol {
     this.closed.complete();
   }
 
-  connectionMade = async (useIpv4: boolean, portRange?: [number, number]) => {
+  connectionMade = async (
+    useIpv4: boolean,
+    portRange?: [number, number],
+    interfaceAddresses?: InterfaceAddresses
+  ) => {
     if (useIpv4) {
-      this.transport = await UdpTransport.init("udp4", portRange);
+      this.transport = await UdpTransport.init(
+        "udp4",
+        portRange,
+        interfaceAddresses
+      );
     } else {
-      this.transport = await UdpTransport.init("udp6", portRange);
+      this.transport = await UdpTransport.init(
+        "udp6",
+        portRange,
+        interfaceAddresses
+      );
     }
 
     this.transport.onData = (data, addr) => this.datagramReceived(data, addr);

--- a/packages/ice/src/transport.ts
+++ b/packages/ice/src/transport.ts
@@ -1,7 +1,11 @@
 import debug from "debug";
 import { createSocket, SocketType } from "dgram";
 
-import { findPort } from "../../common/src";
+import {
+  findPort,
+  interfaceAddress,
+  InterfaceAddresses,
+} from "../../common/src";
 import { Address } from "./types/model";
 import { normalizeFamilyNodeV18 } from "./utils";
 
@@ -11,7 +15,11 @@ export class UdpTransport implements Transport {
   private socket = createSocket(this.type);
   onData: (data: Buffer, addr: Address) => void = () => {};
 
-  constructor(private type: SocketType, private portRange?: [number, number]) {
+  constructor(
+    private type: SocketType,
+    private portRange?: [number, number],
+    private interfaceAddresses?: InterfaceAddresses
+  ) {
     this.socket.on("message", (data, info) => {
       if (normalizeFamilyNodeV18(info.family) === 6) {
         [info.address] = info.address.split("%"); // example fe80::1d3a:8751:4ffd:eb80%wlp82s0
@@ -24,22 +32,28 @@ export class UdpTransport implements Transport {
     });
   }
 
-  static async init(type: SocketType, portRange?: [number, number]) {
-    const transport = new UdpTransport(type, portRange);
+  static async init(
+    type: SocketType,
+    portRange?: [number, number],
+    interfaceAddresses?: InterfaceAddresses
+  ) {
+    const transport = new UdpTransport(type, portRange, interfaceAddresses);
     await transport.init();
     return transport;
   }
 
   private async init() {
+    const address = interfaceAddress(this.type, this.interfaceAddresses);
     if (this.portRange) {
       const port = await findPort(
         this.portRange[0],
         this.portRange[1],
-        this.type
+        this.type,
+        this.interfaceAddresses
       );
-      this.socket.bind(port);
+      this.socket.bind({ port, address });
     } else {
-      this.socket.bind();
+      this.socket.bind({ address });
     }
     await new Promise((r) => this.socket.once("listening", r));
   }

--- a/packages/ice/src/turn/protocol.ts
+++ b/packages/ice/src/turn/protocol.ts
@@ -5,6 +5,7 @@ import PCancelable from "p-cancelable";
 import Event from "rx.mini";
 import { setTimeout } from "timers/promises";
 
+import { InterfaceAddresses } from "../../../common/src/network";
 import { Candidate } from "../candidate";
 import { TransactionFailed } from "../exceptions";
 import { Future, future } from "../helper";
@@ -287,18 +288,24 @@ export async function createTurnEndpoint(
   {
     lifetime,
     portRange,
+    interfaceAddresses,
   }: {
     lifetime?: number;
     ssl?: boolean;
     transport?: "udp";
     portRange?: [number, number];
+    interfaceAddresses?: InterfaceAddresses;
   }
 ) {
   if (lifetime == undefined) {
     lifetime = 600;
   }
 
-  const transport = await UdpTransport.init("udp4", portRange);
+  const transport = await UdpTransport.init(
+    "udp4",
+    portRange,
+    interfaceAddresses
+  );
 
   const turnClient = new TurnClient(
     serverAddr,

--- a/packages/ice/src/utils.ts
+++ b/packages/ice/src/utils.ts
@@ -1,8 +1,12 @@
+import { InterfaceAddresses } from "../../common/src/network";
 import { Connection, serverReflexiveCandidate } from "./ice";
 import { StunProtocol } from "./stun/protocol";
 import { Address } from "./types/model";
 
-export async function getGlobalIp(stunServer?: Address) {
+export async function getGlobalIp(
+  stunServer?: Address,
+  interfaceAddresses?: InterfaceAddresses
+) {
   const connection = new Connection(true, {
     stunServer: stunServer ?? ["stun.l.google.com", 19302],
   });
@@ -10,7 +14,7 @@ export async function getGlobalIp(stunServer?: Address) {
 
   const protocol = new StunProtocol(connection);
   protocol.localCandidate = connection.localCandidates[0];
-  await protocol.connectionMade(true);
+  await protocol.connectionMade(true, undefined, interfaceAddresses);
   const candidate = await serverReflexiveCandidate(protocol, [
     "stun.l.google.com",
     19302,

--- a/packages/webrtc/src/peerConnection.ts
+++ b/packages/webrtc/src/peerConnection.ts
@@ -5,7 +5,7 @@ import Event from "rx.mini";
 import * as uuid from "uuid";
 
 import { Profile } from "../../dtls/src/context/srtp";
-import { deepMerge } from ".";
+import { deepMerge, InterfaceAddresses } from ".";
 import {
   codecParametersFromString,
   DtlsKeys,
@@ -410,6 +410,7 @@ export class RTCPeerConnection extends EventTarget {
       ...parseIceServers(this.config.iceServers),
       forceTurn: this.config.iceTransportPolicy === "relay",
       portRange: this.config.icePortRange,
+      interfaceAddresses: this.config.iceInterfaceAddresses,
     });
     if (existing) {
       iceGatherer.connection.localUserName = existing.connection.localUserName;
@@ -1481,6 +1482,7 @@ export interface PeerConfig {
   iceServers: RTCIceServer[];
   /**Minimum port and Maximum port must not be the same value */
   icePortRange: [number, number] | undefined;
+  iceInterfaceAddresses: InterfaceAddresses | undefined;
   dtls: Partial<{
     keys: DtlsKeys;
   }>;
@@ -1542,6 +1544,7 @@ export const defaultPeerConfig: PeerConfig = {
   iceTransportPolicy: "all",
   iceServers: [{ urls: "stun:stun.l.google.com:19302" }],
   icePortRange: undefined,
+  iceInterfaceAddresses: undefined,
   dtls: {},
   bundlePolicy: "max-compat",
   debug: {},


### PR DESCRIPTION
We require running RTC over a specific network interface, rather than the interface automatically selected by the OS. This can be done by providing an interface's local address in `socket.bind()`. This PR simply adds an config object to specify these addresses for IPv4 and IPv6.

Usage:

```
const peer = new RTCPeerConnection({
    iceInterfaceAddresses: {
        udp4: "172.20.10.2",
        udp6: "fe80::885:4ee3:67cc:3caa%en8",
    },
});
```

Unsure if I've missed anything (as I've only tested candidate gathering so far; ideally it'll use the interface for all traffic) or if there are standards in the repo I've missed.