### PR TITLE
Add iceUseIpv4/6 config to RTCPeerConnection

### DIFF
--- a/packages/webrtc/src/peerConnection.ts
+++ b/packages/webrtc/src/peerConnection.ts
@@ -1510,8 +1510,8 @@ export interface PeerConfig {
   /**Minimum port and Maximum port must not be the same value */
   icePortRange: [number, number] | undefined;
   iceInterfaceAddresses: InterfaceAddresses | undefined;
-  iceUseIpv4: boolean | undefined;
-  iceUseIpv6: boolean | undefined;
+  iceUseIpv4: boolean;
+  iceUseIpv6: boolean;
   dtls: Partial<{
     keys: DtlsKeys;
   }>;
@@ -1576,8 +1576,8 @@ export const defaultPeerConfig: PeerConfig = {
   iceServers: [{ urls: "stun:stun.l.google.com:19302" }],
   icePortRange: undefined,
   iceInterfaceAddresses: undefined,
-  iceUseIpv4: undefined,
-  iceUseIpv6: undefined,
+  iceUseIpv4: true,
+  iceUseIpv6: true,
   dtls: {},
   bundlePolicy: "max-compat",
   debug: {},

--- a/packages/webrtc/src/peerConnection.ts
+++ b/packages/webrtc/src/peerConnection.ts
@@ -436,6 +436,8 @@ export class RTCPeerConnection extends EventTarget {
       forceTurn: this.config.iceTransportPolicy === "relay",
       portRange: this.config.icePortRange,
       interfaceAddresses: this.config.iceInterfaceAddresses,
+      useIpv4: this.config.iceUseIpv4,
+      useIpv6: this.config.iceUseIpv6,
     });
     if (existing) {
       iceGatherer.connection.localUserName = existing.connection.localUserName;
@@ -1508,6 +1510,8 @@ export interface PeerConfig {
   /**Minimum port and Maximum port must not be the same value */
   icePortRange: [number, number] | undefined;
   iceInterfaceAddresses: InterfaceAddresses | undefined;
+  iceUseIpv4: boolean | undefined;
+  iceUseIpv6: boolean | undefined;
   dtls: Partial<{
     keys: DtlsKeys;
   }>;
@@ -1572,6 +1576,8 @@ export const defaultPeerConfig: PeerConfig = {
   iceServers: [{ urls: "stun:stun.l.google.com:19302" }],
   icePortRange: undefined,
   iceInterfaceAddresses: undefined,
+  iceUseIpv4: undefined,
+  iceUseIpv6: undefined,
   dtls: {},
   bundlePolicy: "max-compat",
   debug: {},


### PR DESCRIPTION
With support for using specific interfaces/addresses in #249, if one of the given family addresses is undefined it'll automatically pick one. In some situations this is undesirable and it's instead preferred to not use that family. For example, if wanting to use `eth1`, but it only has an IPv4 address, giving `undefined` for `udp6` address will result in it picking the default address (from, say, `eth0`). In such situations it's desirable to give the ability to disable IPv6.

The underlying connection already has support for `useIpv4`/`useIpv6`, this simply exposes it at the `RTCPeerConnection` level. 