### PR TITLE
Add function to filter STUN responses

### DIFF
--- a/packages/ice/src/ice.ts
+++ b/packages/ice/src/ice.ts
@@ -563,6 +563,13 @@ export class Connection {
       }
     }
 
+    if (
+      this.options.filterStunResponse &&
+      !this.options.filterStunResponse(message, addr, protocol)
+    ) {
+      return;
+    }
+
     // # send binding response
     const response = new Message(
       methods.BINDING,
@@ -960,6 +967,11 @@ export interface IceOptions {
   useIpv6: boolean;
   portRange?: [number, number];
   interfaceAddresses?: InterfaceAddresses;
+  filterStunResponse?: (
+    message: Message,
+    addr: Address,
+    protocol: Protocol
+  ) => boolean;
 }
 
 const defaultOptions: IceOptions = {

--- a/packages/webrtc/src/peerConnection.ts
+++ b/packages/webrtc/src/peerConnection.ts
@@ -5,7 +5,16 @@ import Event from "rx.mini";
 import * as uuid from "uuid";
 
 import { Profile } from "../../dtls/src/context/srtp";
-import { deepMerge, InterfaceAddresses, Recvonly, Sendonly, Sendrecv } from ".";
+import { Message } from "../../ice/src/stun/message";
+import { Protocol } from "../../ice/src/types/model";
+import {
+  Address,
+  deepMerge,
+  InterfaceAddresses,
+  Recvonly,
+  Sendonly,
+  Sendrecv,
+} from ".";
 import {
   codecParametersFromString,
   DtlsKeys,
@@ -436,6 +445,7 @@ export class RTCPeerConnection extends EventTarget {
       forceTurn: this.config.iceTransportPolicy === "relay",
       portRange: this.config.icePortRange,
       interfaceAddresses: this.config.iceInterfaceAddresses,
+      filterStunResponse: this.config.iceFilterStunResponse,
       useIpv4: this.config.iceUseIpv4,
       useIpv6: this.config.iceUseIpv6,
     });
@@ -1512,6 +1522,11 @@ export interface PeerConfig {
   iceInterfaceAddresses: InterfaceAddresses | undefined;
   iceUseIpv4: boolean;
   iceUseIpv6: boolean;
+  /** If provided, is called on each STUN request.
+   * Return `true` if a STUN response should be sent, false if it should be skipped. */
+  iceFilterStunResponse:
+    | ((message: Message, addr: Address, protocol: Protocol) => boolean)
+    | undefined;
   dtls: Partial<{
     keys: DtlsKeys;
   }>;
@@ -1578,6 +1593,7 @@ export const defaultPeerConfig: PeerConfig = {
   iceInterfaceAddresses: undefined,
   iceUseIpv4: true,
   iceUseIpv6: true,
+  iceFilterStunResponse: undefined,
   dtls: {},
   bundlePolicy: "max-compat",
   debug: {},


### PR DESCRIPTION
This adds an optional callback that can filter whether a STUN request should send a response.

For example:
```
const peer = new RTCPeerConnection({
    iceInterfaceAddresses: localAddresses,
    iceFilterStunRequest: (_: Message, addr: Address) => {
        return addr[0] === "10.10.10.1";
    },
});
```

We found this necessary as when doing connections locally, even if you exclude a candidate Chrome still uses it if it sends a STUN response.