### PR TITLE
Fix GenericNack serialization

### DIFF
--- a/packages/rtp/src/rtcp/rtpfb/nack.ts
+++ b/packages/rtp/src/rtcp/rtpfb/nack.ts
@@ -68,7 +68,7 @@ export class GenericNack {
         blp = 0;
       this.lost.slice(1).forEach((p) => {
         const d = p - pid - 1;
-        if (d < 16) {
+        if (d >= 0 && d < 16) {
           blp |= 1 << d;
         } else {
           fci.push(bufferWriter([2, 2], [pid, blp]));

--- a/packages/rtp/tests/rtcp/rtpfb/nack.test.ts
+++ b/packages/rtp/tests/rtcp/rtpfb/nack.test.ts
@@ -18,29 +18,12 @@ describe("rtcp/rtpfb/nack", () => {
   });
 
   test("test descending pids", () => {
-    const data = Buffer.from([
-      ...new RtcpHeader().serialize(),
-      0,
-      0,
-      0,
-      1,
-      17,
-      52,
-      198,
-      225,
-      /* lost[0] */ 183,
-      30,
-      0,
-      1,
-      /* lost[1] */ 9,
-      16,
-      0,
-      0,
-      /* lost[2 & 3] */ 9,
-      36,
-      0,
-      0,
-    ]);
+    const data = Buffer.from(
+      Array.from(new RtcpHeader().serialize()).concat([
+        0, 0, 0, 1, 17, 52, 198, 225, /* lost[0] */ 183, 30, 0, 1,
+        /* lost[1] */ 9, 16, 0, 0, /* lost[2 & 3] */ 9, 36, 0, 0,
+      ])
+    );
     const [rtpfb] = RtcpPacketConverter.deSerialize(data) as [
       RtcpTransportLayerFeedback
     ];

--- a/packages/rtp/tests/rtcp/rtpfb/nack.test.ts
+++ b/packages/rtp/tests/rtcp/rtpfb/nack.test.ts
@@ -1,4 +1,4 @@
-import { RtcpPacketConverter } from "../../../src";
+import { RtcpHeader, RtcpPacketConverter } from "../../../src";
 import { RtcpTransportLayerFeedback } from "../../../src/rtcp/rtpfb";
 import { GenericNack } from "../../../src/rtcp/rtpfb/nack";
 import { load } from "../../utils";
@@ -13,6 +13,39 @@ describe("rtcp/rtpfb/nack", () => {
     expect(nack.lost).toEqual([
       12, 32, 39, 54, 76, 110, 123, 142, 183, 187, 223, 236, 271, 292,
     ]);
+    const res = nack.serialize();
+    expect(res).toEqual(data);
+  });
+
+  test("test descending pids", () => {
+    const data = Buffer.from([
+      ...new RtcpHeader().serialize(),
+      0,
+      0,
+      0,
+      1,
+      17,
+      52,
+      198,
+      225,
+      /* lost[0] */ 183,
+      30,
+      0,
+      1,
+      /* lost[1] */ 9,
+      16,
+      0,
+      0,
+      /* lost[2 & 3] */ 9,
+      36,
+      0,
+      0,
+    ]);
+    const [rtpfb] = RtcpPacketConverter.deSerialize(data) as [
+      RtcpTransportLayerFeedback
+    ];
+    const nack = rtpfb.feedback as GenericNack;
+    expect(nack.lost).toEqual([46878, 46879, 2320, 2340]);
     const res = nack.serialize();
     expect(res).toEqual(data);
   });

--- a/packages/rtp/tests/rtcp/rtpfb/nack.test.ts
+++ b/packages/rtp/tests/rtcp/rtpfb/nack.test.ts
@@ -18,18 +18,12 @@ describe("rtcp/rtpfb/nack", () => {
   });
 
   test("test descending pids", () => {
-    const data = Buffer.from(
-      Array.from(new RtcpHeader().serialize()).concat([
-        0, 0, 0, 1, 17, 52, 198, 225, /* lost[0] */ 183, 30, 0, 1,
-        /* lost[1] */ 9, 16, 0, 0, /* lost[2 & 3] */ 9, 36, 0, 0,
-      ])
-    );
-    const [rtpfb] = RtcpPacketConverter.deSerialize(data) as [
-      RtcpTransportLayerFeedback
+    const data = [
+      0, 0, 0, 1, 17, 52, 198, 225, /* lost[0] */ 183, 30, 0, 1,
+      /* lost[1] */ 9, 16, 0, 0, /* lost[2] */ 9, 36, 0, 0,
     ];
-    const nack = rtpfb.feedback as GenericNack;
-    expect(nack.lost).toEqual([46878, 46879, 2320, 2340]);
-    const res = nack.serialize();
-    expect(res).toEqual(data);
+    const nack = GenericNack.deSerialize(Buffer.from(data), new RtcpHeader());
+    const serialized = nack.serialize();
+    expect(Array.from(serialized).slice(4)).toEqual(data);
   });
 });


### PR DESCRIPTION
The current `GenericNack` `serialize` function has a bug in it where if a subsequent PID is lower that the previous PID it'll crash. This is because `d` becomes a negative number (as `p < pid`), and `blp` would become invalid (i.e. not a 16 bit number).

See the test that was previously failing.