### PR TITLE
Stop old transports when setting a new one

### DIFF
--- a/packages/webrtc/src/media/rtpTransceiver.ts
+++ b/packages/webrtc/src/media/rtpTransceiver.ts
@@ -59,8 +59,13 @@ export class RTCRtpTransceiver {
   }
 
   setDtlsTransport(dtls: RTCDtlsTransport) {
+    const oldTransport = this.dtlsTransport;
     this.receiver.setDtlsTransport(dtls);
     this.sender.setDtlsTransport(dtls);
+    if (oldTransport) {
+      oldTransport.stop();
+      oldTransport.iceTransport.stop();
+    }
   }
 
   get msid() {

--- a/packages/webrtc/src/transport/sctp.ts
+++ b/packages/webrtc/src/transport/sctp.ts
@@ -48,6 +48,7 @@ export class RTCSctpTransport {
 
     this.eventDisposer.forEach((dispose) => dispose());
 
+    const oldTransport = this.dtlsTransport;
     this.dtlsTransport = dtlsTransport;
     this.sctp = new SCTP(new BridgeDtls(this.dtlsTransport), this.port);
 
@@ -90,6 +91,11 @@ export class RTCSctpTransport {
     this.sctp.onSackReceived = async () => {
       await this.dataChannelFlush();
     };
+
+    if (oldTransport) {
+      oldTransport.stop();
+      oldTransport.iceTransport.stop();
+    }
   }
 
   private get isServer() {


### PR DESCRIPTION
We've run in to issues of 'open handles' in tests. It turned out to be sockets not being closed because `setDtlsTransport` was called, removing the reference to them but not stopping them.

See https://github.com/shinyoshiaki/werift-webrtc/blob/develop/packages/webrtc/src/peerConnection.ts#L825, where it creates a transceiver (which creates a new transport) and then later sets a new transport without tidying up the old one.

This implementation assumes that the transceiver and sctp are the only ones who use the transport, if that's not the case it'll need to be changed.