### PR TITLE
replace rtp option to signal the stream contains a discontunity

### DIFF
--- a/packages/webrtc/src/media/rtpSender.ts
+++ b/packages/webrtc/src/media/rtpSender.ts
@@ -283,15 +283,24 @@ export class RTCRtpSender {
     } catch (error) {}
   }
 
-  replaceRTP({
-    sequenceNumber,
-    timestamp,
-  }: Pick<RtpHeader, "sequenceNumber" | "timestamp">) {
+  replaceRTP(
+    {
+      sequenceNumber,
+      timestamp,
+    }: Pick<RtpHeader, "sequenceNumber" | "timestamp">,
+    discontinuity = false
+  ) {
     if (this.sequenceNumber != undefined) {
       this.seqOffset = uint16Add(this.sequenceNumber, -sequenceNumber);
+      if (discontinuity) {
+        this.seqOffset = uint16Add(this.seqOffset, 2);
+      }
     }
     if (this.timestamp != undefined) {
       this.timestampOffset = uint32Add(this.timestamp, -timestamp);
+      if (discontinuity) {
+        this.timestampOffset = uint16Add(this.timestampOffset, 1);
+      }
     }
     this.rtpCache = [];
     log("replaceRTP", this.sequenceNumber, sequenceNumber, this.seqOffset);


### PR DESCRIPTION
This is necessary if replace rtp is called during a h264 fragmentation unit. The decoder will fail to decode until a full key frame interval without this change.