### PR TITLE
Fix 'ipAddressFromSdp' used instead of 'ipAddressToSdp'

### DIFF
--- a/packages/webrtc/src/sdp.ts
+++ b/packages/webrtc/src/sdp.ts
@@ -344,7 +344,7 @@ export class SessionDescription {
   get string() {
     const lines = [`v=${this.version}`, `o=${this.origin}`, `s=${this.name}`];
     if (this.host) {
-      lines.push(`c=${ipAddressFromSdp(this.host)}`);
+      lines.push(`c=${ipAddressToSdp(this.host)}`);
     }
     lines.push(`t=${this.time}`);
     this.group.forEach((group) => lines.push(`a=group:${group.str}`));


### PR DESCRIPTION
The `toJSON` function on `SessionDescription` was crashing because it was calling `ipAddressFromSdp` with `this.host`, which is just an ip address like '0.0.0.0' as it has already been parsed. It instead needs to convert the IP _to_ the SDP string here.
