### PR TITLE
[ICE] Disallow overwriting the nominated candidate pair for a component

### DIFF
--- a/packages/ice/src/ice.ts
+++ b/packages/ice/src/ice.ts
@@ -656,7 +656,12 @@ export class Connection {
   private checkComplete(pair: CandidatePair) {
     pair.handle = undefined;
     if (pair.state === CandidatePairState.SUCCEEDED) {
-      if (pair.nominated) {
+      // Updating the Nominated Flag
+
+      // As per https://www.rfc-editor.org/rfc/rfc8445#section-7.3.1.5, once the nominated 
+      // flag is set then this concludes the ICE processing for this component. So disallow
+      // overwriting of the pair nominated for that component
+      if (pair.nominated && this.nominated[pair.component] === undefined) {
         this.nominated[pair.component] = pair;
 
         // 8.1.2.  Updating States


### PR DESCRIPTION
As per https://www.rfc-editor.org/rfc/rfc8445#section-7.3.1.5, once the nominated flag is set then this concludes the ICE processing for this component. 
This code was allowing it to be overwritten which caused connection state discrepancies as the STUN requests were not being sent on the correct pair, so the solution is to disallow overwriting of the pair nominated for that component.