### PR TITLE
check ice port is used

### DIFF
--- a/packages/common/src/network.ts
+++ b/packages/common/src/network.ts
@@ -60,10 +60,13 @@ export async function findPort(
       })
     );
 
-    await new Promise<void>((r) => {
+    const err = await new Promise<Error | undefined>((r) => {
       socket.once("error", r);
       socket.once("listening", r);
     });
+    if (err) {
+      continue;
+    }
 
     port = socket.address()?.port;
     await new Promise<void>((r) => socket.close(() => r()));


### PR DESCRIPTION
When I use `icePortRange` by running werift as `cluster worker` then `port = socket.address()?.port;` return instead of 0 throws an error which throws an exception in `setRemoteDescription` for some reason.

```sh
Error set remote description  {
  e: 'getsockname EBADF',
  stack: 'Error: getsockname EBADF\n' +
    '    at Socket.address (node:dgram:756:11)\n' +
    '    at findPort (/usr/local/share/applications/uyem/node_modules/werift/lib/common/src/network.js:41:23)\n' +
    '    at processTicksAndRejections (node:internal/process/task_queues:96:5)\n' +
    '    at async UdpTransport.init (/usr/local/share/applications/uyem/node_modules/werift/lib/ice/src/transport.js:61:26)\n' +
    '    at async Function.init (/usr/local/share/applications/uyem/node_modules/werift/lib/ice/src/transport.js:53:9)\n' +
    '    at async StunProtocol.connectionMade (/usr/local/share/applications/uyem/node_modules/werift/lib/ice/src/stun/protocol.js:22:34)\n' +
    '    at async Connection.getComponentCandidates (/usr/local/share/applications/uyem/node_modules/werift/lib/ice/src/ice.js:245:13)\n' +
    '    at async Connection.gatherCandidates (/usr/local/share/applications/uyem/node_modules/werift/lib/ice/src/ice.js:232:36)\n' +
    '    at async RTCIceGatherer.gather (/usr/local/share/applications/uyem/node_modules/werift/lib/webrtc/src/transport/ice.js:107:13)\n' +
    '    at async RTCPeerConnection.setRemoteDescription (/usr/local/share/applications/uyem/node_modules/werift/lib/webrtc/src/peerConnection.js:755:3)',
} 

```

I put a check on whether the socket port is busy, so that in case of an error, go to the next iteration of the loop and once again not run `port = socket.address()?.port;`. Everything worked for me.
