### PR TITLE
set default value for packString attribute

### DIFF
--- a/packages/ice/src/stun/attributes.ts
+++ b/packages/ice/src/stun/attributes.ts
@@ -94,7 +94,7 @@ const unpackUnsigned64 = (data: Buffer) => {
   return BigInt(int.toString());
 };
 
-const packString = (value: string) => Buffer.from(value, "utf8");
+const packString = (value = "") => Buffer.from(value, "utf8");
 const unpackString = (data: Buffer) => data.toString("utf8");
 
 const packBytes = (value: Buffer) => value;


### PR DESCRIPTION
As turn server, I use coturn on the local machine, realm is listed as localhost. Periodically throws an exception from `setRemoteDescription`. 
```sh
[0] [1]  error  Error set remote description  {
[0] [1]   e: 'The first argument must be of type string or an instance of Buffer, ArrayBuffer, or Array or an Array-like Object. Received undefined',
[0] [1]   stack: 'TypeError [ERR_INVALID_ARG_TYPE]: The first argument must be of type string or an instance of Buffer, ArrayBuffer, or Array or an Array-like Object. Received undefined\n' +
[0] [1]     '    at new NodeError (node:internal/errors:372:5)\n' +
[0] [1]     '    at Function.from (node:buffer:323:9)\n' +
[0] [1]     '    at packString (/home/user/Projects/werift-sfu-react/node_modules/werift/lib/ice/src/stun/attributes.js:111:38)\n' +
[0] [1]     '    at Message.get bytes [as bytes] (/home/user/Projects/werift-sfu-react/node_modules/werift/lib/ice/src/stun/message.js:77:19)\n' +
[0] [1]     '    at Message.messageIntegrity (/home/user/Projects/werift-sfu-react/node_modules/werift/lib/ice/src/stun/message.js:99:46)\n' +
[0] [1]     '    at Message.addMessageIntegrity (/home/user/Projects/werift-sfu-react/node_modules/werift/lib/ice/src/stun/message.js:95:53)\n' +
[0] [1]     '    at TurnClient.request (/home/user/Projects/werift-sfu-react/node_modules/werift/lib/ice/src/turn/protocol.js:181:18)\n' +
[0] [1]     '    at TurnClient.connect (/home/user/Projects/werift-sfu-react/node_modules/werift/lib/ice/src/turn/protocol.js:154:39)\n' +
[0] [1]     '    at async createTurnEndpoint (/home/user/Projects/werift-sfu-react/node_modules/werift/lib/ice/src/turn/protocol.js:232:5)\n' +
[0] [1]     '    at async Connection.getComponentCandidates (/home/user/Projects/werift-sfu-react/node_modules/werift/lib/ice/src/ice.js:284:30)',
[0] [1] } 
```
In packages/ice/src/stun/message.ts, I displayed the field name and value, it turns out that the value realm is `undefined`.
```sh
[0] [1] LIFETIME 600
[0] [1] REQUESTED-TRANSPORT 285212672
[0] [1] REQUESTED-TRANSPORT 285212672
[0] [1] USERNAME username
[0] [1] REALM undefined
```

When I set default value to `packString` then this error is gone.