### PR TITLE
fix ending ports

### DIFF
--- a/packages/common/src/network.ts
+++ b/packages/common/src/network.ts
@@ -65,6 +65,7 @@ export async function findPort(
       socket.once("listening", () => r());
     });
     if (err) {
+      await new Promise<void>((r) => socket.close(() => r()));
       continue;
     }
 


### PR DESCRIPTION
Without forced closing of sockets when checking ports, for some reason the ports run out very quickly, immediately from the second run of the tests.
https://www.youtube.com/watch?v=bg6PRstijG8