### PR TITLE
fix initializer vs constructor order

### DIFF
--- a/packages/dtls/src/context/transport.ts
+++ b/packages/dtls/src/context/transport.ts
@@ -1,9 +1,9 @@
 import { Transport } from "../transport";
 
 export class TransportContext {
-  constructor(public socket: Transport) {
-    this.send = this.socket.send;
-  }
+  constructor(public socket: Transport) {}
 
-  readonly send: (arg0: Buffer) => void;
+  readonly send = (buf: Buffer) => {
+    return this.socket.send(buf);
+  };
 }

--- a/packages/dtls/src/context/transport.ts
+++ b/packages/dtls/src/context/transport.ts
@@ -1,7 +1,9 @@
 import { Transport } from "../transport";
 
 export class TransportContext {
-  constructor(public socket: Transport) {}
+  constructor(public socket: Transport) {
+    this.send = this.socket.send;
+  }
 
-  readonly send = this.socket.send;
+  readonly send: (arg0: Buffer) => void;
 }

--- a/packages/dtls/src/socket.ts
+++ b/packages/dtls/src/socket.ts
@@ -35,16 +35,9 @@ export class DtlsSocket {
   readonly onData = new Event<[Buffer]>();
   readonly onError = new Event<[Error]>();
   readonly onClose = new Event();
-  readonly transport: TransportContext = new TransportContext(
-    this.options.transport
-  );
-  cipher: CipherContext = new CipherContext(
-    this.sessionType,
-    this.options.cert,
-    this.options.key,
-    this.options.signatureHash
-  );
-  dtls: DtlsContext = new DtlsContext(this.options, this.sessionType);
+  readonly transport: TransportContext;
+  cipher: CipherContext;
+  dtls: DtlsContext;
   srtp: SrtpContext = new SrtpContext();
 
   connected = false;
@@ -54,6 +47,14 @@ export class DtlsSocket {
   private bufferFragmentedHandshakes: FragmentedHandshake[] = [];
 
   constructor(public options: Options, public sessionType: SessionTypes) {
+    this.dtls = new DtlsContext(this.options, this.sessionType);
+    this.cipher = new CipherContext(
+      this.sessionType,
+      this.options.cert,
+      this.options.key,
+      this.options.signatureHash
+    );
+    this.transport = new TransportContext(this.options.transport);
     this.setupExtensions();
     this.transport.socket.onData = this.udpOnMessage;
   }

--- a/packages/ice/src/stun/transaction.ts
+++ b/packages/ice/src/stun/transaction.ts
@@ -12,8 +12,7 @@ export class Transaction {
   private timeoutDelay = RETRY_RTO;
   private timeoutHandle?: any;
   private tries = 0;
-  private readonly triesMax =
-    1 + (this.retransmissions ? this.retransmissions : RETRY_MAX);
+  private readonly triesMax: number;
   private readonly onResponse = new Event<[Message, Address]>();
 
   constructor(
@@ -21,7 +20,10 @@ export class Transaction {
     private addr: Address,
     private protocol: Protocol,
     private retransmissions?: number
-  ) {}
+  ) {
+    this.triesMax =
+      1 + (this.retransmissions ? this.retransmissions : RETRY_MAX);
+  }
 
   responseReceived = (message: Message, addr: Address) => {
     if (this.onResponse.length > 0) {

--- a/packages/ice/src/transport.ts
+++ b/packages/ice/src/transport.ts
@@ -1,5 +1,5 @@
 import debug from "debug";
-import { createSocket, SocketType } from "dgram";
+import { createSocket, Socket, SocketType } from "dgram";
 
 import {
   findPort,
@@ -12,7 +12,7 @@ import { normalizeFamilyNodeV18 } from "./utils";
 const log = debug("werift-ice:packages/ice/src/transport.ts");
 
 export class UdpTransport implements Transport {
-  private socket = createSocket(this.type);
+  private socket: Socket;
   onData: (data: Buffer, addr: Address) => void = () => {};
 
   constructor(
@@ -20,6 +20,7 @@ export class UdpTransport implements Transport {
     private portRange?: [number, number],
     private interfaceAddresses?: InterfaceAddresses
   ) {
+    this.socket = createSocket(this.type);
     this.socket.on("message", (data, info) => {
       if (normalizeFamilyNodeV18(info.family) === 6) {
         [info.address] = info.address.split("%"); // example fe80::1d3a:8751:4ffd:eb80%wlp82s0

--- a/packages/rtp/src/processor/lipsync.ts
+++ b/packages/rtp/src/processor/lipsync.ts
@@ -13,22 +13,22 @@ export type LipsyncOutput = {
 };
 
 export class LipsyncBase implements AVProcessor<LipsyncInput> {
-  bufferLength = this.options.bufferLength ?? 50;
+  bufferLength: number;
   /**ms */
   baseTime?: number;
   audioBuffer: (LipsyncInput & {
     elapsed: number;
     kind: string;
     [key: string]: any;
-  })[][] = [...new Array(this.bufferLength)].map(() => []);
+  })[][];
   videoBuffer: (LipsyncInput & {
     elapsed: number;
     kind: string;
     [key: string]: any;
-  })[][] = [...new Array(this.bufferLength)].map(() => []);
+  })[][];
   stopped = false;
   /**ms */
-  private interval = this.options.interval ?? 500;
+  private interval: number;
   private started = false;
   /**ms */
   lastCommited = 0;
@@ -37,7 +37,12 @@ export class LipsyncBase implements AVProcessor<LipsyncInput> {
     private audioOutput: (output: LipsyncOutput) => void,
     private videoOutput: (output: LipsyncOutput) => void,
     private options: Partial<LipSyncOptions> = {}
-  ) {}
+  ) {
+    this.bufferLength = this.options.bufferLength ?? 50;
+    this.audioBuffer = [...new Array(this.bufferLength)].map(() => []);
+    this.videoBuffer = [...new Array(this.bufferLength)].map(() => []);
+    this.interval = this.options.interval ?? 500;
+  }
 
   private start() {
     // 2列目にカーソルが移ってから処理を始めることで1列目の処理を完了できる

--- a/packages/sctp/src/sctp.ts
+++ b/packages/sctp/src/sctp.ts
@@ -99,7 +99,7 @@ export class SCTP {
 
   private hmacKey = randomBytes(16);
   private localPartialReliability = true;
-  private localPort = this.port;
+  private localPort: number;
   private localVerificationTag = random32();
 
   remoteExtensions: number[] = [];
@@ -166,6 +166,7 @@ export class SCTP {
   private ssthresh?: number; // slow start threshold
 
   constructor(public transport: Transport, public port = 5000) {
+    this.localPort = this.port;
     this.transport.onData = (buf) => {
       this.handleData(buf);
     };

--- a/packages/webrtc/src/dataChannel.ts
+++ b/packages/webrtc/src/dataChannel.ts
@@ -20,7 +20,7 @@ export class RTCDataChannel extends EventTarget {
   // todo impl
   onerror?: CallbackWithValue<RTCErrorEvent>;
   isCreatedByRemote = false;
-  id: number = this.parameters.id;
+  id: number;
   readyState: DCState = "connecting";
 
   bufferedAmount = 0;
@@ -32,6 +32,8 @@ export class RTCDataChannel extends EventTarget {
     public readonly sendOpen = true
   ) {
     super();
+
+    this.id = this.parameters.id;
 
     if (parameters.negotiated) {
       if (this.id == undefined || this.id < 0 || this.id > 65534) {

--- a/packages/webrtc/src/media/rtpSender.ts
+++ b/packages/webrtc/src/media/rtpSender.ts
@@ -72,10 +72,7 @@ const RTT_ALPHA = 0.85;
 
 export class RTCRtpSender {
   readonly type = "sender";
-  readonly kind =
-    typeof this.trackOrKind === "string"
-      ? this.trackOrKind
-      : this.trackOrKind.kind;
+  readonly kind: Kind;
   readonly ssrc = jspack.Unpack("!L", randomBytes(4))[0];
   readonly rtxSsrc = jspack.Unpack("!L", randomBytes(4))[0];
   streamId = uuid.v4();
@@ -124,6 +121,10 @@ export class RTCRtpSender {
   private rtcpCancel = new AbortController();
 
   constructor(public trackOrKind: Kind | MediaStreamTrack) {
+    this.kind =
+      typeof this.trackOrKind === "string"
+        ? this.trackOrKind
+        : this.trackOrKind.kind;
     if (trackOrKind instanceof MediaStreamTrack) {
       if (trackOrKind.streamId) {
         this.streamId = trackOrKind.streamId;

--- a/packages/webrtc/src/transport/dtls.ts
+++ b/packages/webrtc/src/transport/dtls.ts
@@ -334,7 +334,6 @@ export class RTCDtlsParameters {
 
 class IceTransport implements Transport {
   constructor(private ice: Connection) {
-    this.send = this.ice.send;
     ice.onData.subscribe((buf) => {
       if (isDtls(buf)) {
         if (this.onData) this.onData(buf);
@@ -343,7 +342,9 @@ class IceTransport implements Transport {
   }
   onData?: (buf: Buffer) => void;
 
-  readonly send: (data: Buffer) => Promise<void>;
+  readonly send = (data: Buffer) => {
+    return this.ice.send(data);
+  };
 
   close() {
     this.ice.close();

--- a/packages/webrtc/src/transport/dtls.ts
+++ b/packages/webrtc/src/transport/dtls.ts
@@ -49,7 +49,7 @@ export class RTCDtlsTransport {
 
   readonly onStateChange = new Event<[DtlsState]>();
 
-  localCertificate?: RTCCertificate = this.certificates[0];
+  localCertificate?: RTCCertificate;
   private remoteParameters?: RTCDtlsParameters;
 
   constructor(
@@ -58,7 +58,9 @@ export class RTCDtlsTransport {
     readonly router: RtpRouter,
     readonly certificates: RTCCertificate[],
     private readonly srtpProfiles: Profile[] = []
-  ) {}
+  ) {
+    this.localCertificate = this.certificates[0];
+  }
 
   get localParameters() {
     return new RTCDtlsParameters(
@@ -332,6 +334,7 @@ export class RTCDtlsParameters {
 
 class IceTransport implements Transport {
   constructor(private ice: Connection) {
+    this.send = this.ice.send;
     ice.onData.subscribe((buf) => {
       if (isDtls(buf)) {
         if (this.onData) this.onData(buf);
@@ -340,7 +343,7 @@ class IceTransport implements Transport {
   }
   onData?: (buf: Buffer) => void;
 
-  readonly send = this.ice.send;
+  readonly send: (data: Buffer) => Promise<void>;
 
   close() {
     this.ice.close();

--- a/packages/webrtc/src/transport/ice.ts
+++ b/packages/webrtc/src/transport/ice.ts
@@ -9,7 +9,7 @@ const log = debug("werift:packages/webrtc/src/transport/ice.ts");
 
 export class RTCIceTransport {
   readonly id = v4();
-  connection = this.gather.connection;
+  connection: Connection;
   state: RTCIceConnectionState = "new";
 
   readonly onStateChange = new Event<[RTCIceConnectionState]>();
@@ -17,6 +17,7 @@ export class RTCIceTransport {
   private waitStart?: Event<[]>;
 
   constructor(private gather: RTCIceGatherer) {
+    this.connection = this.gather.connection;
     this.connection.stateChanged.subscribe((state) => {
       this.setState(state);
     });
@@ -116,9 +117,11 @@ export class RTCIceGatherer {
   gatheringState: IceGathererState = "new";
 
   readonly onGatheringStateChange = new Event<[IceGathererState]>();
-  readonly connection = new Connection(false, this.options);
+  readonly connection: Connection;
 
-  constructor(private options: Partial<IceOptions> = {}) {}
+  constructor(private options: Partial<IceOptions> = {}) {
+    this.connection = new Connection(false, this.options);
+  }
 
   async gather() {
     if (this.gatheringState === "new") {

--- a/packages/webrtc/src/transport/sctp.ts
+++ b/packages/webrtc/src/transport/sctp.ts
@@ -377,10 +377,12 @@ export class RTCSctpCapabilities {
 }
 
 class BridgeDtls implements Transport {
-  constructor(private dtls: RTCDtlsTransport) {}
+  constructor(private dtls: RTCDtlsTransport) {
+    this.send = this.dtls.sendData;
+  }
   set onData(onData: (buf: Buffer) => void) {
     this.dtls.dataReceiver = onData;
   }
-  readonly send = this.dtls.sendData;
+  readonly send: (arg0: Buffer) => any;
   close() {}
 }

--- a/packages/webrtc/src/transport/sctp.ts
+++ b/packages/webrtc/src/transport/sctp.ts
@@ -377,12 +377,12 @@ export class RTCSctpCapabilities {
 }
 
 class BridgeDtls implements Transport {
-  constructor(private dtls: RTCDtlsTransport) {
-    this.send = this.dtls.sendData;
-  }
+  constructor(private dtls: RTCDtlsTransport) {}
   set onData(onData: (buf: Buffer) => void) {
     this.dtls.dataReceiver = onData;
   }
-  readonly send: (arg0: Buffer) => any;
+  readonly send = (data: Buffer) => {
+    return this.dtls.sendData(data);
+  };
   close() {}
 }


### PR DESCRIPTION
I'm embedding the typescript files directly, and not using the werift build. There's a bug where typescript is initializing members before constructor parameters. This fixes those bugs.