### PR TITLE
set MediaRecorder.start as public method

### DIFF
--- a/packages/webrtc/src/nonstandard/recorder/index.ts
+++ b/packages/webrtc/src/nonstandard/recorder/index.ts
@@ -30,7 +30,7 @@ export class MediaRecorder {
     await this.start();
   }
 
-  private async start() {
+  async start() {
     if (this.tracks.length === this.numOfTracks && this.started === false) {
       this.started = true;
       await this.writer.start(this.tracks);


### PR DESCRIPTION
While building throw error:
```sh
src/addons/recordVideo.ts:359:45 - error TS2341: Property 'start' is private and only accessible within class 'MediaRecorder'.

359     this.mediaRecorders[roomId][recorderId].start();
                                                ~~~~~
```