### PR TITLE
docs: make README showcase werift strengths

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,78 +1,293 @@
+<div align="center">
+
 # werift
 
-werift (**We**b**r**tc **I**mplementation **f**or **T**ypeScript)
+### Programmable WebRTC for TypeScript & Node.js
 
-werift is a WebRTC Implementation for TypeScript (Node.js), includes ICE/DTLS/SCTP/RTP.
+Build media servers, gateways, recorders, bots, test peers, and custom real-time pipelines with a WebRTC stack you can inspect and extend all the way down to **RTP, RTCP, ICE, DTLS, SRTP, SCTP, and DataChannel**.
 
-## Repository setup
+[![npm version](https://img.shields.io/npm/v/werift)](https://www.npmjs.com/package/werift)
+[![npm downloads](https://img.shields.io/npm/dm/werift)](https://www.npmjs.com/package/werift)
+[![license](https://img.shields.io/npm/l/werift)](./LICENSE)
+[![node](https://img.shields.io/node/v/werift)](https://www.npmjs.com/package/werift)
+[![GitHub stars](https://img.shields.io/github/stars/shinyoshiaki/werift-webrtc?style=social)](https://github.com/shinyoshiaki/werift-webrtc)
 
-Initialize the pinned upstream WPT submodule before running the WPT compatibility tooling:
+[Documentation](https://shinyoshiaki.github.io/werift-webrtc/website/build/) · [API Reference](https://shinyoshiaki.github.io/werift-webrtc/website/build/docs/api) · [Examples](./examples) · [Issues](https://github.com/shinyoshiaki/werift-webrtc/issues)
 
-```sh
-git submodule update --init --recursive
+</div>
+
+---
+
+**werift** (**We**b**R**TC **I**mplementation **f**or **T**ypeScript) is a WebRTC implementation for Node.js written in TypeScript.
+
+It gives you a high-level `RTCPeerConnection` API when you want to build quickly, while still exposing the protocol layers and RTP packets needed for server-side media systems where the browser abstraction is not enough.
+
+## Why werift?
+
+- **TypeScript from PeerConnection down to the protocols** — work with WebRTC without wrapping a native browser engine or opaque native WebRTC binding.
+- **RTP-first media model** — receive and send encoded RTP directly, making werift a natural fit for SFUs, recorders, relays, gateways, bots, and custom media processing.
+- **Modular protocol stack** — ICE, DTLS, SCTP, and RTP are also available as focused packages for applications that do not need the whole WebRTC stack.
+- **Built for interoperability** — compatibility is tracked against Chrome, Safari, Firefox, Pion, aiortc, sipsorcery, and webrtc-rs.
+- **Server-oriented building blocks** — full/lite ICE, trickle ICE, ICE restart, STUN/TURN, DTLS-SRTP, DataChannel, RTP/RTCP feedback, simulcast receive, sender-side bandwidth estimation, and recording utilities.
+- **Inspectable and extensible** — the packet path is yours. Add RTP transformations, custom congestion logic, protocol experiments, logging, or test instrumentation without crossing a native boundary.
+
+## Install
+
+```bash
+npm install werift
 ```
 
-# install
+The published `werift` package supports Node.js 16 or newer.
 
-`npm install werift`
+## Quick start
 
-requires at least Node.js 16
+A complete in-process DataChannel connection can be created with only two peer connections and ordinary offer/answer signaling:
 
-# Documentation (WIP)
+```ts
+import { RTCPeerConnection } from "werift";
 
-- [Website](https://shinyoshiaki.github.io/werift-webrtc/website/build/)
-- [API Reference](https://shinyoshiaki.github.io/werift-webrtc/website/build/docs/api)
+const offerer = new RTCPeerConnection({});
+const answerer = new RTCPeerConnection({});
 
-# examples
+answerer.onDataChannel.subscribe((channel) => {
+  channel.onMessage.subscribe((message) => {
+    console.log("answerer received:", message.toString());
+    channel.send(Buffer.from("hello from answerer"));
+  });
+});
 
-https://github.com/shinyoshiaki/werift-webrtc/tree/master/examples
+const channel = offerer.createDataChannel("chat");
 
-- TURN/TLS HTTPS loopback sample: `examples/turn-loopback`
-- Audio RED (RFC 2198) send/recv sample: `examples/mediachannel/red`
-- RTP processing utilities (jitter buffer, RED encoder/decoder, DTX, NACK, lip sync): `packages/rtp/src/extra/processor`
+channel.stateChanged.subscribe((state) => {
+  if (state === "open") {
+    channel.send(Buffer.from("hello from offerer"));
+  }
+});
 
-### SFU
+channel.onMessage.subscribe((message) => {
+  console.log("offerer received:", message.toString());
+});
 
-https://github.com/shinyoshiaki/node-sfu
+await offerer.setLocalDescription(await offerer.createOffer());
+await answerer.setRemoteDescription(offerer.localDescription!);
 
-# demo
+await answerer.setLocalDescription(await answerer.createAnswer());
+await offerer.setRemoteDescription(answerer.localDescription!);
+```
 
-## MediaChannel
+In a real application, replace the direct description exchange with your signaling transport: WebSocket, HTTP, SIP infrastructure, a queue, or anything else appropriate for your system.
 
-```sh
+See [`examples/datachannel`](./examples/datachannel) for runnable variants.
+
+## A WebRTC stack that stays programmable
+
+Browser WebRTC intentionally hides most packet-level details. Server-side systems often need the opposite.
+
+werift does **not** try to provide browser capture/render APIs such as `getUserMedia()`. Instead, media can enter and leave the WebRTC stack as RTP packets. That makes it straightforward to connect werift to your own encoder, decoder, transcoder, recorder, RTP router, media pipeline, or test harness.
+
+```mermaid
+flowchart LR
+  APP[Your TypeScript application]
+  PC[RTCPeerConnection]
+  SDP[SDP / negotiation]
+  ICE[ICE + STUN / TURN]
+  DTLS[DTLS]
+  SCTP[SCTP]
+  DC[DataChannel]
+  SRTP[SRTP / SRTCP]
+  RTP[RTP / RTCP]
+  MEDIA[Recorder / SFU / gateway / custom media pipeline]
+
+  APP --> PC
+  PC --> SDP
+  PC --> ICE
+  ICE --> DTLS
+  DTLS --> SCTP --> DC --> APP
+  DTLS --> SRTP --> RTP --> MEDIA
+  MEDIA --> RTP
+```
+
+This design is especially useful when you need to understand, transform, record, relay, or test the media packets themselves.
+
+## Features
+
+| Area | Highlights |
+| --- | --- |
+| **PeerConnection** | Offer/answer negotiation, media directions, multiple tracks, DataChannel |
+| **ICE** | Full ICE, ICE-Lite client/server modes, trickle ICE, ICE restart, STUN, TURN |
+| **TURN transports** | UDP and TCP support, plus TURN/TLS loopback examples |
+| **Security** | DTLS-SRTP, Curve25519, P-256, SRTP, SRTCP |
+| **DataChannel** | SCTP over DTLS |
+| **RTP / RTCP** | RFC 3550, SR/RR, PLI, Generic NACK, REMB, Transport-Wide CC |
+| **Media resilience** | RTX and RED (RFC 2198) |
+| **RTP payloads** | VP8, VP9, H.264, and AV1 RTP payload parsing |
+| **Simulcast** | Receive-side simulcast |
+| **Bandwidth estimation** | Sender-side BWE |
+| **Recording** | MediaRecorder support for Opus, VP8, VP9, H.264, and AV1 workflows |
+| **RTP processing** | Jitter buffer, RED encoder/decoder, DTX, NACK, lip-sync and other packet processors |
+
+> werift is a WebRTC transport and media-packet stack. Codec capture, rendering, and general-purpose encode/decode are intentionally outside the core abstraction.
+
+## What can you build?
+
+### SFUs and RTP routers
+
+Receive encoded RTP, inspect or transform it, then forward it to other peers without forcing your application through a browser-style media pipeline.
+
+A separate SFU project built with werift is available at [node-sfu](https://github.com/shinyoshiaki/node-sfu).
+
+### Recording and media ingestion
+
+Record incoming WebRTC media or connect RTP to your existing storage/transcoding pipeline. See [`examples/save_to_disk`](./examples/save_to_disk) and the non-standard recorder APIs.
+
+### Gateways and protocol bridges
+
+Use WebRTC as one side of a larger system: SIP/media gateways, device bridges, realtime backends, relay services, or application-specific transports.
+
+### Automated WebRTC peers
+
+Because the stack runs in Node.js and exposes packet/protocol state, it works well for integration tests, interoperability suites, synthetic peers, load tests, and protocol debugging.
+
+### Protocol experimentation
+
+Use the lower layers directly when you need custom ICE, DTLS, SCTP, RTP/RTCP, congestion-control, or packet-processing behavior.
+
+## Modular packages
+
+You can use the full WebRTC package or only the protocol layer you need.
+
+| Package | Purpose |
+| --- | --- |
+| [`werift`](https://www.npmjs.com/package/werift) | Complete WebRTC stack and `RTCPeerConnection` |
+| [`werift-ice`](https://www.npmjs.com/package/werift-ice) | ICE / STUN / TURN implementation |
+| [`werift-dtls`](https://www.npmjs.com/package/werift-dtls) | DTLS implementation |
+| [`werift-sctp`](https://www.npmjs.com/package/werift-sctp) | SCTP implementation |
+| [`werift-rtp`](https://www.npmjs.com/package/werift-rtp) | RTP / RTCP / SRTP / SRTCP and RTP processing utilities |
+
+The top-level `werift` package also exports lower-level WebRTC transport and RTP primitives, so applications can mix high-level PeerConnection behavior with packet-level control.
+
+## Interoperability
+
+WebRTC only becomes useful when independent implementations can actually connect. Interoperability is therefore treated as a first-class concern.
+
+Compatibility is tracked with:
+
+- Chrome
+- Safari
+- Firefox
+- Pion
+- aiortc
+- sipsorcery
+- webrtc-rs
+
+The repository includes browser E2E coverage and interoperability work with the [`webrtc-echoes`](https://github.com/sipsorcery/webrtc-echoes) ecosystem.
+
+## Examples
+
+The [`examples`](./examples) directory contains runnable examples for both high-level WebRTC use cases and lower-level media/protocol work.
+
+| Example | What it demonstrates |
+| --- | --- |
+| [`examples/datachannel`](./examples/datachannel) | DataChannel offer/answer and messaging |
+| [`examples/mediachannel`](./examples/mediachannel) | Sending and receiving WebRTC media |
+| [`examples/save_to_disk`](./examples/save_to_disk) | Recording encoded WebRTC media |
+| [`examples/turn-loopback`](./examples/turn-loopback) | TURN/TLS HTTPS loopback |
+| [`examples/interop`](./examples/interop) | Interoperability-oriented peers and relay examples |
+| [`examples/getStats`](./examples/getStats) | Statistics-related example code |
+| [`packages/rtp/src/extra/processor`](./packages/rtp/src/extra/processor) | Jitter buffering, RED, DTX, NACK, lip sync, and RTP processing utilities |
+
+## Live demos
+
+### MediaChannel
+
+```bash
 npm run media
 ```
 
-open
+Then open:
+
 https://shinyoshiaki.github.io/werift-webrtc/examples/mediachannel/pubsub/answer
 
-see console & chrome://webrtc-internals/
+Use the browser console and `chrome://webrtc-internals/` to inspect the connection.
 
-## DataChannel
+### DataChannel
 
-run
-
-```sh
+```bash
 npm run datachannel
 ```
 
-open
+Then open:
+
 https://shinyoshiaki.github.io/werift-webrtc/examples/datachannel/answer
 
-see console & chrome://webrtc-internals/
+Again, the browser console and `chrome://webrtc-internals/` are useful for inspecting signaling, ICE, DTLS, SCTP, and DataChannel behavior.
 
-# RoadMap
+## Debugging
 
-## Work in Progress Towards 1.0
+werift uses the [`debug`](https://www.npmjs.com/package/debug) package throughout the stack.
+
+```bash
+DEBUG=werift* node your-app.js
+```
+
+For browser interoperability debugging, combine server logs with:
+
+- `chrome://webrtc-internals/`
+- SDP offer/answer dumps
+- ICE candidate logs
+- RTP/RTCP packet-level instrumentation
+
+Because the implementation is TypeScript, protocol behavior can be traced directly from application-level events down into the relevant transport code.
+
+## Documentation
+
+- [Documentation website](https://shinyoshiaki.github.io/werift-webrtc/website/build/)
+- [API reference](https://shinyoshiaki.github.io/werift-webrtc/website/build/docs/api)
+- [Examples](./examples)
+
+Documentation coverage is still evolving. The examples and source are intentionally kept accessible for developers working at protocol level.
+
+## Repository setup
+
+If you are contributing to werift itself, initialize the pinned upstream Web Platform Tests submodule before running the WPT compatibility tooling:
+
+```bash
+git submodule update --init --recursive
+```
+
+The repository-level development tooling requires Node.js 18 or newer.
+
+## Roadmap
+
+### Towards 1.0
+
+The core WebRTC transport and media packet stack is already implemented. Current work towards 1.0 focuses on hardening and developer experience:
+
+- [ ] Expand and improve documentation
+- [ ] Increase Web Platform Tests coverage
+- [ ] Continue strengthening unit, E2E, interoperability, and long-running reliability tests
+
+### Towards 2.0
+
+- [ ] Closer browser `RTCPeerConnection` API compatibility
+- [ ] Simulcast send support
+- [ ] Additional cipher suites
+- [ ] Richer WebRTC statistics coverage
+
+## Protocol coverage at a glance
+
+<details>
+<summary>Implemented protocol/features checklist</summary>
 
 - [x] STUN
 - [x] TURN
   - [x] UDP
+  - [x] TCP
 - [x] ICE
-  - [x] Vanilla ICE
+  - [x] Full ICE
   - [x] Trickle ICE
-  - [x] ICE-Lite Client Side
-  - [x] ICE-Lite Server Side
+  - [x] ICE-Lite client side
+  - [x] ICE-Lite server side
   - [x] ICE restart
 - [x] DTLS
   - [x] DTLS-SRTP
@@ -83,68 +298,46 @@ see console & chrome://webrtc-internals/
   - [x] sendonly
   - [x] recvonly
   - [x] sendrecv
-  - [x] multi track
+  - [x] multi-track
   - [x] RTX
   - [x] RED
 - [x] RTP
   - [x] RFC 3550
-  - [x] Parse RTP Payload Format for VP8 Video
-  - [x] Parse RTP Payload Format for VP9 Video
-  - [x] Parse RTP Payload Format for H264 Video
-  - [x] Parse RTP Payload Format for AV1 Video
+  - [x] VP8 RTP payload parsing
+  - [x] VP9 RTP payload parsing
+  - [x] H.264 RTP payload parsing
+  - [x] AV1 RTP payload parsing
   - [x] RED (RFC 2198)
 - [x] RTCP
   - [x] SR/RR
   - [x] Picture Loss Indication
-  - [x] ReceiverEstimatedMaxBitrate
-  - [x] GenericNack
-  - [x] TransportWideCC
+  - [x] Receiver Estimated Maximum Bitrate
+  - [x] Generic NACK
+  - [x] Transport-Wide CC
 - [x] SRTP
 - [x] SRTCP
 - [x] SDP
-  - [x] reuse inactive m-line
+  - [x] Reuse inactive m-lines
 - [x] PeerConnection
-- [x] Simulcast
-  - [x] recv
-- [x] BWE
-  - [x] sender side BWE
-- [ ] Documentation
-- [x] Compatibility
-  - [x] Chrome
-  - [x] Safari
-  - [x] FireFox
-  - [x] Pion
-  - [x] aiortc
-  - [x] sipsorcery
-  - [x] webrtc-rs
-- [x] Interop E2E test
-  - [x] Chrome
-  - ↓↓↓ https://github.com/sipsorcery/webrtc-echoes
-  - [x] Pion
-  - [x] aiortc
-  - [x] sipsorcery
-  - [x] webrtc-rs
-- [ ] Unit Tests
-  - [ ] follow [Web Platform Tests](https://github.com/web-platform-tests/wpt)
-- [x] MediaRecorder
-  - [x] OPUS
+- [x] Simulcast receive
+- [x] Sender-side bandwidth estimation
+- [x] MediaRecorder workflows
+  - [x] Opus
   - [x] VP8
-  - [x] H264
+  - [x] H.264
   - [x] VP9
   - [x] AV1
 
-## Road Map Towards 2.0
+</details>
 
-- [ ] API compatible with browser RTCPeerConnection
-- [ ] Simulcast
-  - [ ] send
-- [ ] support more cipher suites
-- [ ] getStats
-- [x] TURN
-  - [x] TCP
+## References
 
-# reference
+werift has benefited from the wider WebRTC implementation ecosystem, including:
 
-- aiortc https://github.com/aiortc/aiortc
-- pion/webrtc https://github.com/pion/webrtc
-- etc ....
+- [aiortc](https://github.com/aiortc/aiortc)
+- [Pion WebRTC](https://github.com/pion/webrtc)
+- [sipsorcery](https://github.com/sipsorcery/webrtc-echoes)
+
+## License
+
+MIT

--- a/README.md
+++ b/README.md
@@ -193,7 +193,6 @@ werift is a participating implementation in [`sipsorcery/webrtc-interop`](https:
 - Pion
 - SIPSorcery
 - webrtc-rs
-- webrtc-server
 
 This provides an independent interoperability signal in addition to werift's own E2E tests.
 

--- a/README.md
+++ b/README.md
@@ -12,24 +12,25 @@ Build media servers, gateways, recorders, bots, test peers, and custom real-time
 [![node](https://img.shields.io/node/v/werift)](https://www.npmjs.com/package/werift)
 [![GitHub stars](https://img.shields.io/github/stars/shinyoshiaki/werift-webrtc?style=social)](https://github.com/shinyoshiaki/werift-webrtc)
 
-[Documentation](https://shinyoshiaki.github.io/werift-webrtc/website/build/) · [API Reference](https://shinyoshiaki.github.io/werift-webrtc/website/build/docs/api) · [Examples](./examples) · [Issues](https://github.com/shinyoshiaki/werift-webrtc/issues)
+[Documentation](https://shinyoshiaki.github.io/werift-webrtc/website/build/) · [API Reference](https://shinyoshiaki.github.io/werift-webrtc/website/build/docs/api) · [Examples](./examples) · [Interoperability](#interoperability) · [Roadmap](#roadmap)
 
 </div>
 
 ---
 
-**werift** (**We**b**R**TC **I**mplementation **f**or **T**ypeScript) is a WebRTC implementation for Node.js written in TypeScript.
+**werift** (**We**b**r**tc **I**mplementation **f**or **T**ypeScript) is a WebRTC implementation for Node.js written in TypeScript.
 
-It gives you a high-level `RTCPeerConnection` API when you want to build quickly, while still exposing the protocol layers and RTP packets needed for server-side media systems where the browser abstraction is not enough.
+Use the familiar `RTCPeerConnection` model when you want to build quickly, then drop down into ICE, DTLS, SCTP, RTP/RTCP, or individual packets when your server-side application needs more control than a browser abstraction can provide.
 
 ## Why werift?
 
-- **TypeScript from PeerConnection down to the protocols** — work with WebRTC without wrapping a native browser engine or opaque native WebRTC binding.
+- **TypeScript from PeerConnection down to the protocols** — build WebRTC without wrapping a native browser engine or opaque native WebRTC binding.
+- **Familiar WebRTC APIs, deeper control** — W3C-style PeerConnection configuration, events, descriptions, ICE candidates, tracks, and DataChannels coexist with werift's lower-level primitives.
 - **RTP-first media model** — receive and send encoded RTP directly, making werift a natural fit for SFUs, recorders, relays, gateways, bots, and custom media processing.
-- **Modular protocol stack** — ICE, DTLS, SCTP, and RTP are also available as focused packages for applications that do not need the whole WebRTC stack.
+- **Modular protocol stack** — ICE, DTLS, SCTP, and RTP are also published as focused packages for applications that do not need the whole WebRTC stack.
 - **Built for interoperability** — compatibility is tracked against Chrome, Safari, Firefox, Pion, aiortc, sipsorcery, and webrtc-rs.
-- **Server-oriented building blocks** — full/lite ICE, trickle ICE, ICE restart, STUN/TURN, DTLS-SRTP, DataChannel, RTP/RTCP feedback, simulcast receive, sender-side bandwidth estimation, and recording utilities.
-- **Inspectable and extensible** — the packet path is yours. Add RTP transformations, custom congestion logic, protocol experiments, logging, or test instrumentation without crossing a native boundary.
+- **Server-oriented building blocks** — full/lite ICE, trickle ICE, ICE restart, STUN/TURN, DTLS-SRTP, RTP/RTCP feedback, simulcast receive, sender-side bandwidth estimation, recording, and RTP processing utilities.
+- **Inspectable and extensible** — add RTP transforms, custom congestion logic, protocol experiments, logging, or test instrumentation without crossing a native boundary.
 
 ## Install
 
@@ -41,32 +42,30 @@ The published `werift` package supports Node.js 16 or newer.
 
 ## Quick start
 
-A complete in-process DataChannel connection can be created with only two peer connections and ordinary offer/answer signaling:
+The public API is intentionally familiar to browser WebRTC developers:
 
 ```ts
 import { RTCPeerConnection } from "werift";
 
-const offerer = new RTCPeerConnection({});
-const answerer = new RTCPeerConnection({});
+const offerer = new RTCPeerConnection();
+const answerer = new RTCPeerConnection();
 
-answerer.onDataChannel.subscribe((channel) => {
-  channel.onMessage.subscribe((message) => {
-    console.log("answerer received:", message.toString());
-    channel.send(Buffer.from("hello from answerer"));
-  });
-});
+answerer.ondatachannel = ({ channel }) => {
+  channel.onmessage = ({ data }) => {
+    console.log("answerer received:", data.toString());
+    channel.send("hello from answerer");
+  };
+};
 
 const channel = offerer.createDataChannel("chat");
 
-channel.stateChanged.subscribe((state) => {
-  if (state === "open") {
-    channel.send(Buffer.from("hello from offerer"));
-  }
-});
+channel.onopen = () => {
+  channel.send("hello from offerer");
+};
 
-channel.onMessage.subscribe((message) => {
-  console.log("offerer received:", message.toString());
-});
+channel.onmessage = ({ data }) => {
+  console.log("offerer received:", data.toString());
+};
 
 await offerer.setLocalDescription(await offerer.createOffer());
 await answerer.setRemoteDescription(offerer.localDescription!);
@@ -75,15 +74,30 @@ await answerer.setLocalDescription(await answerer.createAnswer());
 await offerer.setRemoteDescription(answerer.localDescription!);
 ```
 
-In a real application, replace the direct description exchange with your signaling transport: WebSocket, HTTP, SIP infrastructure, a queue, or anything else appropriate for your system.
+Here the two peers exchange SDP directly. In a real application, move that exchange to your signaling transport: WebSocket, HTTP, SIP infrastructure, a queue, or anything else appropriate for your system.
 
 See [`examples/datachannel`](./examples/datachannel) for runnable variants.
+
+## Familiar API without giving up the internals
+
+werift is actively converging on browser-compatible `RTCPeerConnection` behavior while preserving server-side control and backward compatibility.
+
+Current W3C-style surface includes, among other things:
+
+- standard PeerConnection events such as `icecandidate`, `track`, `datachannel`, `negotiationneeded`, and connection/signaling state changes
+- `addEventListener` support alongside werift's event subscriptions
+- `currentLocalDescription`, `pendingLocalDescription`, `currentRemoteDescription`, and `pendingRemoteDescription`
+- `canTrickleIceCandidates` and `sctp`
+- `RTCConfiguration` fields such as `iceServers`, `iceTransportPolicy`, `bundlePolicy`, `rtcpMuxPolicy`, `iceCandidatePoolSize`, and `certificates`
+- W3C-style ICE server URL arrays and end-of-candidates handling
+
+Some browser compatibility details intentionally remain different for backward compatibility. See [`packages/webrtc/README.md`](./packages/webrtc/README.md#rtcpeerconnection-w3c-compatibility-notes) for the current compatibility notes.
 
 ## A WebRTC stack that stays programmable
 
 Browser WebRTC intentionally hides most packet-level details. Server-side systems often need the opposite.
 
-werift does **not** try to provide browser capture/render APIs such as `getUserMedia()`. Instead, media can enter and leave the WebRTC stack as RTP packets. That makes it straightforward to connect werift to your own encoder, decoder, transcoder, recorder, RTP router, media pipeline, or test harness.
+werift does **not** try to provide browser capture/render APIs such as `getUserMedia()`. Instead, media can enter and leave the WebRTC stack as RTP packets. Connect those packets to your own encoder, decoder, transcoder, recorder, RTP router, media pipeline, or test harness.
 
 ```mermaid
 flowchart LR
@@ -113,18 +127,18 @@ This design is especially useful when you need to understand, transform, record,
 
 | Area | Highlights |
 | --- | --- |
-| **PeerConnection** | Offer/answer negotiation, media directions, multiple tracks, DataChannel |
+| **PeerConnection** | Offer/answer negotiation, transceivers, media directions, multiple tracks, DataChannel, W3C-style events/configuration |
 | **ICE** | Full ICE, ICE-Lite client/server modes, trickle ICE, ICE restart, STUN, TURN |
 | **TURN transports** | UDP and TCP support, plus TURN/TLS loopback examples |
 | **Security** | DTLS-SRTP, Curve25519, P-256, SRTP, SRTCP |
-| **DataChannel** | SCTP over DTLS |
+| **DataChannel** | SCTP over DTLS, ordered/unordered and reliability controls |
 | **RTP / RTCP** | RFC 3550, SR/RR, PLI, Generic NACK, REMB, Transport-Wide CC |
 | **Media resilience** | RTX and RED (RFC 2198) |
 | **RTP payloads** | VP8, VP9, H.264, and AV1 RTP payload parsing |
 | **Simulcast** | Receive-side simulcast |
 | **Bandwidth estimation** | Sender-side BWE |
 | **Recording** | MediaRecorder support for Opus, VP8, VP9, H.264, and AV1 workflows |
-| **RTP processing** | Jitter buffer, RED encoder/decoder, DTX, NACK, lip-sync and other packet processors |
+| **RTP processing** | Jitter buffer, RED encoder/decoder, DTX, NACK, lip sync, and other packet processors |
 
 > werift is a WebRTC transport and media-packet stack. Codec capture, rendering, and general-purpose encode/decode are intentionally outside the core abstraction.
 
@@ -154,7 +168,7 @@ Use the lower layers directly when you need custom ICE, DTLS, SCTP, RTP/RTCP, co
 
 ## Modular packages
 
-You can use the full WebRTC package or only the protocol layer you need.
+Use the complete WebRTC stack or only the protocol layer you need.
 
 | Package | Purpose |
 | --- | --- |
@@ -244,6 +258,7 @@ Because the implementation is TypeScript, protocol behavior can be traced direct
 - [Documentation website](https://shinyoshiaki.github.io/werift-webrtc/website/build/)
 - [API reference](https://shinyoshiaki.github.io/werift-webrtc/website/build/docs/api)
 - [Examples](./examples)
+- [RTCPeerConnection W3C compatibility notes](./packages/webrtc/README.md#rtcpeerconnection-w3c-compatibility-notes)
 
 Documentation coverage is still evolving. The examples and source are intentionally kept accessible for developers working at protocol level.
 
@@ -261,15 +276,16 @@ The repository-level development tooling requires Node.js 18 or newer.
 
 ### Towards 1.0
 
-The core WebRTC transport and media packet stack is already implemented. Current work towards 1.0 focuses on hardening and developer experience:
+The core WebRTC transport and media packet stack is already implemented. Current work towards 1.0 focuses on hardening, standards compatibility, and developer experience:
 
 - [ ] Expand and improve documentation
 - [ ] Increase Web Platform Tests coverage
+- [ ] Continue converging on browser `RTCPeerConnection` behavior while preserving backward compatibility
 - [ ] Continue strengthening unit, E2E, interoperability, and long-running reliability tests
 
 ### Towards 2.0
 
-- [ ] Closer browser `RTCPeerConnection` API compatibility
+- [ ] Complete the remaining browser API compatibility gaps
 - [ ] Simulcast send support
 - [ ] Additional cipher suites
 - [ ] Richer WebRTC statistics coverage

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ### Programmable WebRTC for TypeScript & Node.js
 
-Build media servers, gateways, recorders, bots, test peers, and custom real-time pipelines with a WebRTC stack you can inspect and extend all the way down to **RTP, RTCP, ICE, DTLS, SRTP, SCTP, and DataChannel**.
+Build media servers, gateways, recorders, bots, test peers, and custom real-time pipelines with a WebRTC stack you can inspect and extend down to **ICE, DTLS, SCTP, RTP/RTCP, SRTP/SRTCP, and DataChannel**.
 
 [![npm version](https://img.shields.io/npm/v/werift)](https://www.npmjs.com/package/werift)
 [![npm downloads](https://img.shields.io/npm/dm/werift)](https://www.npmjs.com/package/werift)
@@ -18,19 +18,19 @@ Build media servers, gateways, recorders, bots, test peers, and custom real-time
 
 ---
 
-**werift** (**We**b**r**tc **I**mplementation **f**or **T**ypeScript) is a WebRTC implementation for Node.js written in TypeScript.
+**werift** (**We**b**R**TC **I**mplementation **f**or **T**ypeScript) is a WebRTC implementation for Node.js written in TypeScript.
 
-Use the familiar `RTCPeerConnection` model when you want to build quickly, then drop down into ICE, DTLS, SCTP, RTP/RTCP, or individual packets when your server-side application needs more control than a browser abstraction can provide.
+Use the familiar `RTCPeerConnection` model when you want to build quickly, then drop down into ICE, DTLS, SCTP, RTP/RTCP, SRTP/SRTCP, or individual packets when your server-side application needs more control than a browser abstraction provides.
 
 ## Why werift?
 
-- **TypeScript from PeerConnection down to the protocols** — build WebRTC without wrapping a native browser engine or opaque native WebRTC binding.
-- **Familiar WebRTC APIs, deeper control** — W3C-style PeerConnection configuration, events, descriptions, ICE candidates, tracks, and DataChannels coexist with werift's lower-level primitives.
-- **RTP-first media model** — receive and send encoded RTP directly, making werift a natural fit for SFUs, recorders, relays, gateways, bots, and custom media processing.
-- **Modular protocol stack** — ICE, DTLS, SCTP, and RTP are also published as focused packages for applications that do not need the whole WebRTC stack.
-- **Built for interoperability** — compatibility is tracked against Chrome, Safari, Firefox, Pion, aiortc, sipsorcery, and webrtc-rs.
-- **Server-oriented building blocks** — full/lite ICE, trickle ICE, ICE restart, STUN/TURN, DTLS-SRTP, RTP/RTCP feedback, simulcast receive, sender-side bandwidth estimation, recording, and RTP processing utilities.
-- **Inspectable and extensible** — add RTP transforms, custom congestion logic, protocol experiments, logging, or test instrumentation without crossing a native boundary.
+- **TypeScript from PeerConnection down to the protocols** — build and debug WebRTC without wrapping a native browser engine or native WebRTC binding.
+- **Familiar WebRTC APIs, deeper control** — W3C-style PeerConnection configuration, events, descriptions, ICE candidates, tracks, DataChannels, and stats coexist with lower-level protocol primitives.
+- **Packet-oriented media control** — send and receive RTP directly, making werift a natural fit for SFUs, recorders, relays, gateways, bots, test peers, and custom media pipelines.
+- **Modern server connectivity** — ICE-Lite, ICE restart, ICE-TCP, and TURN over UDP, TCP, and TLS are implemented in the TypeScript stack.
+- **Modular protocol packages** — use the full PeerConnection stack or focused ICE, DTLS, SCTP, RTP, and STUN/TURN server packages.
+- **Independent interoperability testing** — werift participates in the `sipsorcery/webrtc-interop` Peer Connection and Data Channel Echo matrices alongside other WebRTC implementations.
+- **Inspectable and extensible** — instrument RTP/RTCP, experiment with congestion logic, inspect transport state, or modify protocol behavior without crossing a native boundary.
 
 ## Install
 
@@ -38,7 +38,7 @@ Use the familiar `RTCPeerConnection` model when you want to build quickly, then 
 npm install werift
 ```
 
-The published `werift` package supports Node.js 16 or newer.
+The published `werift` package currently declares Node.js 16 or newer in its package metadata.
 
 ## Quick start
 
@@ -74,7 +74,7 @@ await answerer.setLocalDescription(await answerer.createAnswer());
 await offerer.setRemoteDescription(answerer.localDescription!);
 ```
 
-Here the two peers exchange SDP directly. In a real application, move that exchange to your signaling transport: WebSocket, HTTP, SIP infrastructure, a queue, or anything else appropriate for your system.
+Here the two peers exchange SDP directly. `setLocalDescription()` gathers candidates before resolving, so this compact example can exchange the resulting descriptions without a separate trickle-ICE signaling path. Real applications can also use `onicecandidate` / `addIceCandidate()` and move signaling to WebSocket, HTTP, SIP infrastructure, a queue, or another transport.
 
 See [`examples/datachannel`](./examples/datachannel) for runnable variants.
 
@@ -85,26 +85,27 @@ werift is actively converging on browser-compatible `RTCPeerConnection` behavior
 Current W3C-style surface includes, among other things:
 
 - standard PeerConnection events such as `icecandidate`, `track`, `datachannel`, `negotiationneeded`, and connection/signaling state changes
-- `addEventListener` support alongside werift's event subscriptions
+- `addEventListener` / `removeEventListener` support alongside werift's event subscriptions
 - `currentLocalDescription`, `pendingLocalDescription`, `currentRemoteDescription`, and `pendingRemoteDescription`
 - `canTrickleIceCandidates` and `sctp`
-- `RTCConfiguration` fields such as `iceServers`, `iceTransportPolicy`, `bundlePolicy`, `rtcpMuxPolicy`, `iceCandidatePoolSize`, and `certificates`
-- W3C-style ICE server URL arrays and end-of-candidates handling
+- `RTCConfiguration` fields including `iceServers`, `iceTransportPolicy`, `bundlePolicy`, `rtcpMuxPolicy`, `iceCandidatePoolSize`, and `certificates`
+- ICE server URL arrays and end-of-candidates handling
+- W3C-oriented `getStats()` reports covering RTP, transport, ICE candidates/pairs, codecs, certificates, DataChannels, and related objects
 
 Some browser compatibility details intentionally remain different for backward compatibility. See [`packages/webrtc/README.md`](./packages/webrtc/README.md#rtcpeerconnection-w3c-compatibility-notes) for the current compatibility notes.
 
 ## A WebRTC stack that stays programmable
 
-Browser WebRTC intentionally hides most packet-level details. Server-side systems often need the opposite.
+The core media APIs are packet-oriented: `MediaStreamTrack` can receive and emit RTP, so applications can connect WebRTC directly to an RTP router, recorder, transcoder, media pipeline, or test harness.
 
-werift does **not** try to provide browser capture/render APIs such as `getUserMedia()`. Instead, media can enter and leave the WebRTC stack as RTP packets. Connect those packets to your own encoder, decoder, transcoder, recorder, RTP router, media pipeline, or test harness.
+werift does not provide operating-system camera/microphone capture as part of the core PeerConnection API. The optional [`werift/nonstandard`](./packages/webrtc/src/nonstandard) surface adds server-oriented helpers such as MP4/WebM file playback, configurable/dummy media-device sources, RTP utilities, and recording.
 
 ```mermaid
 flowchart LR
   APP[Your TypeScript application]
   PC[RTCPeerConnection]
   SDP[SDP / negotiation]
-  ICE[ICE + STUN / TURN]
+  ICE[ICE transport]
   DTLS[DTLS]
   SCTP[SCTP]
   DC[DataChannel]
@@ -112,35 +113,37 @@ flowchart LR
   RTP[RTP / RTCP]
   MEDIA[Recorder / SFU / gateway / custom media pipeline]
 
-  APP --> PC
+  APP <--> PC
   PC --> SDP
   PC --> ICE
-  ICE --> DTLS
-  DTLS --> SCTP --> DC --> APP
-  DTLS --> SRTP --> RTP --> MEDIA
-  MEDIA --> RTP
+  ICE <--> DTLS
+  DTLS <--> SCTP <--> DC
+  ICE <--> SRTP <--> RTP <--> MEDIA
+  DTLS -. DTLS-SRTP keying .-> SRTP
 ```
 
-This design is especially useful when you need to understand, transform, record, relay, or test the media packets themselves.
+DTLS and SRTP share the ICE transport, but media is **not tunneled through DTLS**: DTLS negotiates/export keys for SRTP, while encrypted RTP/RTCP packets flow over the selected ICE path.
 
 ## Features
 
 | Area | Highlights |
 | --- | --- |
 | **PeerConnection** | Offer/answer negotiation, transceivers, media directions, multiple tracks, DataChannel, W3C-style events/configuration |
-| **ICE** | Full ICE, ICE-Lite client/server modes, trickle ICE, ICE restart, STUN, TURN |
-| **TURN transports** | UDP and TCP support, plus TURN/TLS loopback examples |
-| **Security** | DTLS-SRTP, Curve25519, P-256, SRTP, SRTCP |
-| **DataChannel** | SCTP over DTLS, ordered/unordered and reliability controls |
+| **ICE** | Full ICE, local ICE-Lite mode, remote ICE-Lite interoperability, trickle ICE, ICE restart, ICE-TCP host candidates |
+| **STUN / TURN** | STUN plus TURN relay control transports over UDP, TCP, and TLS; `turn:` / `turns:` URL handling |
+| **Security** | DTLS-SRTP, SRTP, SRTCP, certificate/fingerprint handling |
+| **DataChannel** | SCTP over DTLS, ordered/unordered delivery and partial-reliability controls |
 | **RTP / RTCP** | RFC 3550, SR/RR, PLI, Generic NACK, REMB, Transport-Wide CC |
 | **Media resilience** | RTX and RED (RFC 2198) |
-| **RTP payloads** | VP8, VP9, H.264, and AV1 RTP payload parsing |
+| **RTP payloads** | RTP helpers for VP8, VP9, H.264, AV1, Opus, and RED-related workflows |
 | **Simulcast** | Receive-side simulcast |
-| **Bandwidth estimation** | Sender-side BWE |
-| **Recording** | MediaRecorder support for Opus, VP8, VP9, H.264, and AV1 workflows |
+| **Bandwidth estimation** | Sender-side estimator driven by Transport-Wide CC feedback |
+| **Statistics** | W3C-oriented `getStats()` report model for RTP, transport, ICE, codec, certificate, DataChannel, and related stats |
+| **Recording** | Nonstandard `MediaRecorder` / WebM writer paths for Opus, VP8, VP9, H.264, and AV1 tracks |
+| **Nonstandard media** | MP4/WebM file playback via mediabunny plus configurable/dummy media-device sources |
 | **RTP processing** | Jitter buffer, RED encoder/decoder, DTX, NACK, lip sync, and other packet processors |
 
-> werift is a WebRTC transport and media-packet stack. Codec capture, rendering, and general-purpose encode/decode are intentionally outside the core abstraction.
+> werift's core strength is WebRTC transport, negotiation, and media-packet control. Device capture, rendering, and general-purpose transcoding remain application concerns; optional nonstandard helpers cover selected server-side media sources and sinks.
 
 ## What can you build?
 
@@ -152,62 +155,68 @@ A separate SFU project built with werift is available at [node-sfu](https://gith
 
 ### Recording and media ingestion
 
-Record incoming WebRTC media or connect RTP to your existing storage/transcoding pipeline. See [`examples/save_to_disk`](./examples/save_to_disk) and the non-standard recorder APIs.
+Record incoming WebRTC media or connect RTP to your existing storage/transcoding pipeline. See [`examples/save_to_disk`](./examples/save_to_disk) and the nonstandard recorder APIs.
 
 ### Gateways and protocol bridges
 
-Use WebRTC as one side of a larger system: SIP/media gateways, device bridges, realtime backends, relay services, or application-specific transports.
+Use WebRTC as one side of a larger system: SIP/media gateways, device bridges, real-time backends, relay services, or application-specific transports.
 
 ### Automated WebRTC peers
 
-Because the stack runs in Node.js and exposes packet/protocol state, it works well for integration tests, interoperability suites, synthetic peers, load tests, and protocol debugging.
+Because the stack runs in Node.js and exposes packet/protocol state, it is useful for integration tests, interoperability suites, synthetic peers, load tests, and protocol debugging.
 
 ### Protocol experimentation
 
-Use the lower layers directly when you need custom ICE, DTLS, SCTP, RTP/RTCP, congestion-control, or packet-processing behavior.
+Use lower layers directly when you need custom ICE, DTLS, SCTP, RTP/RTCP, congestion-control, or packet-processing behavior.
 
 ## Modular packages
 
-Use the complete WebRTC stack or only the protocol layer you need.
+Use the PeerConnection stack or only the protocol layer you need.
 
 | Package | Purpose |
 | --- | --- |
-| [`werift`](https://www.npmjs.com/package/werift) | Complete WebRTC stack and `RTCPeerConnection` |
-| [`werift-ice`](https://www.npmjs.com/package/werift-ice) | ICE / STUN / TURN implementation |
+| [`werift`](https://www.npmjs.com/package/werift) | WebRTC PeerConnection, media transport, DataChannel, and related APIs |
+| [`werift-ice`](https://www.npmjs.com/package/werift-ice) | ICE / STUN / TURN client-side transport implementation |
 | [`werift-dtls`](https://www.npmjs.com/package/werift-dtls) | DTLS implementation |
 | [`werift-sctp`](https://www.npmjs.com/package/werift-sctp) | SCTP implementation |
 | [`werift-rtp`](https://www.npmjs.com/package/werift-rtp) | RTP / RTCP / SRTP / SRTCP and RTP processing utilities |
+| [`werift-ice-server`](https://www.npmjs.com/package/werift-ice-server) | RFC 8489 STUN / RFC 8656 TURN server stack and Node reference implementation |
 
 The top-level `werift` package also exports lower-level WebRTC transport and RTP primitives, so applications can mix high-level PeerConnection behavior with packet-level control.
 
 ## Interoperability
 
-WebRTC only becomes useful when independent implementations can actually connect. Interoperability is therefore treated as a first-class concern.
+Interoperability is tested at more than one level.
 
-Compatibility is tracked with:
+### Browser E2E
 
-- Chrome
-- Safari
-- Firefox
-- Pion
+The repository contains browser E2E tooling and Chromium-focused coverage, including scenarios for ICE-Lite, ICE-TCP, and TURN relay over UDP/TCP/TLS. A Firefox test runner is also included in the E2E workspace.
+
+### Cross-implementation matrix
+
+werift is a participating implementation in [`sipsorcery/webrtc-interop`](https://github.com/sipsorcery/webrtc-interop), which maintains automated Peer Connection and Data Channel Echo tests. Its matrix includes werift alongside implementations such as:
+
 - aiortc
-- sipsorcery
+- libdatachannel
+- Pion
+- SIPSorcery
 - webrtc-rs
+- webrtc-server
 
-The repository includes browser E2E coverage and interoperability work with the [`webrtc-echoes`](https://github.com/sipsorcery/webrtc-echoes) ecosystem.
+This provides an independent interoperability signal in addition to werift's own E2E tests.
 
 ## Examples
 
-The [`examples`](./examples) directory contains runnable examples for both high-level WebRTC use cases and lower-level media/protocol work.
+The [`examples`](./examples) directory contains runnable examples for high-level WebRTC use cases and lower-level media/protocol work.
 
 | Example | What it demonstrates |
 | --- | --- |
 | [`examples/datachannel`](./examples/datachannel) | DataChannel offer/answer and messaging |
 | [`examples/mediachannel`](./examples/mediachannel) | Sending and receiving WebRTC media |
 | [`examples/save_to_disk`](./examples/save_to_disk) | Recording encoded WebRTC media |
-| [`examples/turn-loopback`](./examples/turn-loopback) | TURN/TLS HTTPS loopback |
+| [`examples/turn-loopback`](./examples/turn-loopback) | HTTPS + TURN/TLS multiplexed loopback and Chromium E2E |
 | [`examples/interop`](./examples/interop) | Interoperability-oriented peers and relay examples |
-| [`examples/getStats`](./examples/getStats) | Statistics-related example code |
+| [`examples/getStats`](./examples/getStats) | `getStats()` example code |
 | [`packages/rtp/src/extra/processor`](./packages/rtp/src/extra/processor) | Jitter buffering, RED, DTX, NACK, lip sync, and RTP processing utilities |
 
 ## Live demos
@@ -251,7 +260,7 @@ For browser interoperability debugging, combine server logs with:
 - ICE candidate logs
 - RTP/RTCP packet-level instrumentation
 
-Because the implementation is TypeScript, protocol behavior can be traced directly from application-level events down into the relevant transport code.
+Because the implementation is TypeScript, protocol behavior can be traced directly from application-level events into the relevant transport and packet-processing code.
 
 ## Documentation
 
@@ -260,7 +269,7 @@ Because the implementation is TypeScript, protocol behavior can be traced direct
 - [Examples](./examples)
 - [RTCPeerConnection W3C compatibility notes](./packages/webrtc/README.md#rtcpeerconnection-w3c-compatibility-notes)
 
-Documentation coverage is still evolving. The examples and source are intentionally kept accessible for developers working at protocol level.
+Documentation coverage is still evolving. The examples and source remain useful references for developers working at protocol level.
 
 ## Repository setup
 
@@ -270,13 +279,13 @@ If you are contributing to werift itself, initialize the pinned upstream Web Pla
 git submodule update --init --recursive
 ```
 
-The repository-level development tooling requires Node.js 18 or newer.
+The repository-level package metadata declares Node.js 18 or newer. The opt-in memory-leak harness requires Node.js 24 or newer.
 
 ## Roadmap
 
 ### Towards 1.0
 
-The core WebRTC transport and media packet stack is already implemented. Current work towards 1.0 focuses on hardening, standards compatibility, and developer experience:
+The core WebRTC transport and media-packet stack is implemented. Current work towards 1.0 focuses on hardening, standards compatibility, and developer experience:
 
 - [ ] Expand and improve documentation
 - [ ] Increase Web Platform Tests coverage
@@ -285,7 +294,7 @@ The core WebRTC transport and media packet stack is already implemented. Current
 
 ### Towards 2.0
 
-- [ ] Complete the remaining browser API compatibility gaps
+- [ ] Complete remaining browser API compatibility gaps
 - [ ] Simulcast send support
 - [ ] Additional cipher suites
 - [ ] Richer WebRTC statistics coverage
@@ -296,20 +305,24 @@ The core WebRTC transport and media packet stack is already implemented. Current
 <summary>Implemented protocol/features checklist</summary>
 
 - [x] STUN
-- [x] TURN
-  - [x] UDP
-  - [x] TCP
+- [x] TURN relay client
+  - [x] UDP control transport
+  - [x] TCP control transport
+  - [x] TLS control transport (`turns:`)
+- [x] STUN / TURN server package
+  - [x] RFC 8489 STUN
+  - [x] RFC 8656 TURN
+  - [x] Node reference server
 - [x] ICE
   - [x] Full ICE
   - [x] Trickle ICE
-  - [x] ICE-Lite client side
-  - [x] ICE-Lite server side
+  - [x] Local ICE-Lite mode
+  - [x] Remote ICE-Lite interoperability
   - [x] ICE restart
+  - [x] ICE-TCP host candidates
 - [x] DTLS
-  - [x] DTLS-SRTP
-  - [x] Curve25519
-  - [x] P-256
-- [x] DataChannel
+  - [x] DTLS-SRTP keying
+- [x] DataChannel / SCTP
 - [x] MediaChannel
   - [x] sendonly
   - [x] recvonly
@@ -319,10 +332,10 @@ The core WebRTC transport and media packet stack is already implemented. Current
   - [x] RED
 - [x] RTP
   - [x] RFC 3550
-  - [x] VP8 RTP payload parsing
-  - [x] VP9 RTP payload parsing
-  - [x] H.264 RTP payload parsing
-  - [x] AV1 RTP payload parsing
+  - [x] VP8 RTP helpers
+  - [x] VP9 RTP helpers
+  - [x] H.264 RTP helpers
+  - [x] AV1 RTP helpers
   - [x] RED (RFC 2198)
 - [x] RTCP
   - [x] SR/RR
@@ -337,12 +350,16 @@ The core WebRTC transport and media packet stack is already implemented. Current
 - [x] PeerConnection
 - [x] Simulcast receive
 - [x] Sender-side bandwidth estimation
-- [x] MediaRecorder workflows
+- [x] W3C-oriented `getStats()` model
+- [x] Nonstandard MediaRecorder workflows
   - [x] Opus
   - [x] VP8
   - [x] H.264
   - [x] VP9
   - [x] AV1
+- [x] Nonstandard media helpers
+  - [x] MP4/WebM file playback
+  - [x] configurable/dummy media-device sources
 
 </details>
 
@@ -352,7 +369,7 @@ werift has benefited from the wider WebRTC implementation ecosystem, including:
 
 - [aiortc](https://github.com/aiortc/aiortc)
 - [Pion WebRTC](https://github.com/pion/webrtc)
-- [sipsorcery](https://github.com/sipsorcery/webrtc-echoes)
+- [sipsorcery/webrtc-interop](https://github.com/sipsorcery/webrtc-interop)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -280,7 +280,6 @@ The core WebRTC transport, browser-compatible API, and media-packet stack are im
 
 - [ ] Expand and improve documentation
 - [ ] Increase Web Platform Tests coverage
-- [ ] Close remaining documented browser API edge-case differences
 - [ ] Continue strengthening unit, E2E, interoperability, and long-running reliability tests
 
 ### Towards 2.0

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ### Programmable WebRTC for TypeScript & Node.js
 
-Build media servers, gateways, recorders, bots, test peers, and custom real-time pipelines with a WebRTC stack you can inspect and extend down to **ICE, DTLS, SCTP, RTP/RTCP, SRTP/SRTCP, and DataChannel**.
+Build media servers, gateways, recorders, bots, test peers, and custom real-time pipelines with a **browser-compatible WebRTC API** backed by a TypeScript stack you can inspect and extend down to **ICE, DTLS, SCTP, RTP/RTCP, SRTP/SRTCP, and DataChannel**.
 
 [![npm version](https://img.shields.io/npm/v/werift)](https://www.npmjs.com/package/werift)
 [![npm downloads](https://img.shields.io/npm/dm/werift)](https://www.npmjs.com/package/werift)
@@ -20,12 +20,12 @@ Build media servers, gateways, recorders, bots, test peers, and custom real-time
 
 **werift** (**We**b**R**TC **I**mplementation **f**or **T**ypeScript) is a WebRTC implementation for Node.js written in TypeScript.
 
-Use the familiar `RTCPeerConnection` model when you want to build quickly, then drop down into ICE, DTLS, SCTP, RTP/RTCP, SRTP/SRTCP, or individual packets when your server-side application needs more control than a browser abstraction provides.
+Use the browser-compatible `RTCPeerConnection` API when you want to build quickly, then drop down into ICE, DTLS, SCTP, RTP/RTCP, SRTP/SRTCP, or individual packets when your server-side application needs more control than a browser abstraction provides.
 
 ## Why werift?
 
+- **Browser-compatible WebRTC API** — use familiar `RTCPeerConnection`, tracks, transceivers, DataChannels, standard events, ICE configuration, and stats in Node.js.
 - **TypeScript from PeerConnection down to the protocols** — build and debug WebRTC without wrapping a native browser engine or native WebRTC binding.
-- **Familiar WebRTC APIs, deeper control** — W3C-style PeerConnection configuration, events, descriptions, ICE candidates, tracks, DataChannels, and stats coexist with lower-level protocol primitives.
 - **Packet-oriented media control** — send and receive RTP directly, making werift a natural fit for SFUs, recorders, relays, gateways, bots, test peers, and custom media pipelines.
 - **Modern server connectivity** — ICE-Lite, ICE restart, ICE-TCP, and TURN over UDP, TCP, and TLS are implemented in the TypeScript stack.
 - **Modular protocol packages** — use the full PeerConnection stack or focused ICE, DTLS, SCTP, RTP, and STUN/TURN server packages.
@@ -42,7 +42,7 @@ The published `werift` package currently declares Node.js 16 or newer in its pac
 
 ## Quick start
 
-The public API is intentionally familiar to browser WebRTC developers:
+The API follows the familiar browser WebRTC model:
 
 ```ts
 import { RTCPeerConnection } from "werift";
@@ -78,21 +78,11 @@ Here the two peers exchange SDP directly. `setLocalDescription()` gathers candid
 
 See [`examples/datachannel`](./examples/datachannel) for runnable variants.
 
-## Familiar API without giving up the internals
+## Browser-compatible WebRTC API
 
-werift is actively converging on browser-compatible `RTCPeerConnection` behavior while preserving server-side control and backward compatibility.
+werift exposes a browser-compatible WebRTC API for normal application code, including PeerConnection negotiation, tracks/transceivers, DataChannels, standard events, ICE configuration, and `getStats()`.
 
-Current W3C-style surface includes, among other things:
-
-- standard PeerConnection events such as `icecandidate`, `track`, `datachannel`, `negotiationneeded`, and connection/signaling state changes
-- `addEventListener` / `removeEventListener` support alongside werift's event subscriptions
-- `currentLocalDescription`, `pendingLocalDescription`, `currentRemoteDescription`, and `pendingRemoteDescription`
-- `canTrickleIceCandidates` and `sctp`
-- `RTCConfiguration` fields including `iceServers`, `iceTransportPolicy`, `bundlePolicy`, `rtcpMuxPolicy`, `iceCandidatePoolSize`, and `certificates`
-- ICE server URL arrays and end-of-candidates handling
-- W3C-oriented `getStats()` reports covering RTP, transport, ICE candidates/pairs, codecs, certificates, DataChannels, and related objects
-
-Some browser compatibility details intentionally remain different for backward compatibility. See [`packages/webrtc/README.md`](./packages/webrtc/README.md#rtcpeerconnection-w3c-compatibility-notes) for the current compatibility notes.
+A small number of intentional or known edge-case differences remain for backward compatibility or unsupported legacy APIs. They are documented separately in [Browser API compatibility](./docs/browser-api-compatibility.md), together with the WPT strategy used to track exact browser behavior.
 
 ## A WebRTC stack that stays programmable
 
@@ -122,13 +112,13 @@ flowchart LR
   DTLS -. DTLS-SRTP keying .-> SRTP
 ```
 
-DTLS and SRTP share the ICE transport, but media is **not tunneled through DTLS**: DTLS negotiates/export keys for SRTP, while encrypted RTP/RTCP packets flow over the selected ICE path.
+DTLS and SRTP share the ICE transport, but media is **not tunneled through DTLS**: DTLS negotiates/exports keys for SRTP, while encrypted RTP/RTCP packets flow over the selected ICE path.
 
 ## Features
 
 | Area | Highlights |
 | --- | --- |
-| **PeerConnection** | Offer/answer negotiation, transceivers, media directions, multiple tracks, DataChannel, W3C-style events/configuration |
+| **Browser API** | `RTCPeerConnection`, tracks/transceivers, DataChannel, standard events, ICE configuration, and browser-compatible negotiation behavior |
 | **ICE** | Full ICE, local ICE-Lite mode, remote ICE-Lite interoperability, trickle ICE, ICE restart, ICE-TCP host candidates |
 | **STUN / TURN** | STUN plus TURN relay control transports over UDP, TCP, and TLS; `turn:` / `turns:` URL handling |
 | **Security** | DTLS-SRTP, SRTP, SRTCP, certificate/fingerprint handling |
@@ -138,7 +128,7 @@ DTLS and SRTP share the ICE transport, but media is **not tunneled through DTLS*
 | **RTP payloads** | RTP helpers for VP8, VP9, H.264, AV1, Opus, and RED-related workflows |
 | **Simulcast** | Receive-side simulcast |
 | **Bandwidth estimation** | Sender-side estimator driven by Transport-Wide CC feedback |
-| **Statistics** | W3C-oriented `getStats()` report model for RTP, transport, ICE, codec, certificate, DataChannel, and related stats |
+| **Statistics** | Browser-compatible `getStats()` report model for RTP, transport, ICE, codec, certificate, DataChannel, and related stats |
 | **Recording** | Nonstandard `MediaRecorder` / WebM writer paths for Opus, VP8, VP9, H.264, and AV1 tracks |
 | **Nonstandard media** | MP4/WebM file playback via mediabunny plus configurable/dummy media-device sources |
 | **RTP processing** | Jitter buffer, RED encoder/decoder, DTX, NACK, lip sync, and other packet processors |
@@ -175,14 +165,14 @@ Use the PeerConnection stack or only the protocol layer you need.
 
 | Package | Purpose |
 | --- | --- |
-| [`werift`](https://www.npmjs.com/package/werift) | WebRTC PeerConnection, media transport, DataChannel, and related APIs |
+| [`werift`](https://www.npmjs.com/package/werift) | Browser-compatible WebRTC API, media transport, DataChannel, and related APIs |
 | [`werift-ice`](https://www.npmjs.com/package/werift-ice) | ICE / STUN / TURN client-side transport implementation |
 | [`werift-dtls`](https://www.npmjs.com/package/werift-dtls) | DTLS implementation |
 | [`werift-sctp`](https://www.npmjs.com/package/werift-sctp) | SCTP implementation |
 | [`werift-rtp`](https://www.npmjs.com/package/werift-rtp) | RTP / RTCP / SRTP / SRTCP and RTP processing utilities |
 | [`werift-ice-server`](https://www.npmjs.com/package/werift-ice-server) | RFC 8489 STUN / RFC 8656 TURN server stack and Node reference implementation |
 
-The top-level `werift` package also exports lower-level WebRTC transport and RTP primitives, so applications can mix high-level PeerConnection behavior with packet-level control.
+The top-level `werift` package also exports lower-level WebRTC transport and RTP primitives, so applications can mix the browser-compatible API with packet-level control.
 
 ## Interoperability
 
@@ -269,7 +259,7 @@ Because the implementation is TypeScript, protocol behavior can be traced direct
 - [Documentation website](https://shinyoshiaki.github.io/werift-webrtc/website/build/)
 - [API reference](https://shinyoshiaki.github.io/werift-webrtc/website/build/docs/api)
 - [Examples](./examples)
-- [RTCPeerConnection W3C compatibility notes](./packages/webrtc/README.md#rtcpeerconnection-w3c-compatibility-notes)
+- [Browser API compatibility differences](./docs/browser-api-compatibility.md)
 
 Documentation coverage is still evolving. The examples and source remain useful references for developers working at protocol level.
 
@@ -287,16 +277,15 @@ The repository-level package metadata declares Node.js 18 or newer. The opt-in m
 
 ### Towards 1.0
 
-The core WebRTC transport and media-packet stack is implemented. Current work towards 1.0 focuses on hardening, standards compatibility, and developer experience:
+The core WebRTC transport, browser-compatible API, and media-packet stack are implemented. Current work towards 1.0 focuses on hardening, test coverage, and developer experience:
 
 - [ ] Expand and improve documentation
 - [ ] Increase Web Platform Tests coverage
-- [ ] Continue converging on browser `RTCPeerConnection` behavior while preserving backward compatibility
+- [ ] Close remaining documented browser API edge-case differences
 - [ ] Continue strengthening unit, E2E, interoperability, and long-running reliability tests
 
 ### Towards 2.0
 
-- [ ] Complete remaining browser API compatibility gaps
 - [ ] Simulcast send support
 - [ ] Additional cipher suites
 - [ ] Richer WebRTC statistics coverage
@@ -306,6 +295,7 @@ The core WebRTC transport and media-packet stack is implemented. Current work to
 <details>
 <summary>Implemented protocol/features checklist</summary>
 
+- [x] Browser-compatible WebRTC API
 - [x] STUN
 - [x] TURN relay client
   - [x] UDP control transport
@@ -352,7 +342,7 @@ The core WebRTC transport and media-packet stack is implemented. Current work to
 - [x] PeerConnection
 - [x] Simulcast receive
 - [x] Sender-side bandwidth estimation
-- [x] W3C-oriented `getStats()` model
+- [x] Browser-compatible `getStats()` model
 - [x] Nonstandard MediaRecorder workflows
   - [x] Opus
   - [x] VP8

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Use the familiar `RTCPeerConnection` model when you want to build quickly, then 
 - **Packet-oriented media control** — send and receive RTP directly, making werift a natural fit for SFUs, recorders, relays, gateways, bots, test peers, and custom media pipelines.
 - **Modern server connectivity** — ICE-Lite, ICE restart, ICE-TCP, and TURN over UDP, TCP, and TLS are implemented in the TypeScript stack.
 - **Modular protocol packages** — use the full PeerConnection stack or focused ICE, DTLS, SCTP, RTP, and STUN/TURN server packages.
-- **Independent interoperability testing** — werift participates in the `sipsorcery/webrtc-interop` Peer Connection and Data Channel Echo matrices alongside other WebRTC implementations.
+- **Interoperability evidence at multiple levels** — Chromium-focused E2E coverage, a Firefox test runner, community-reported Safari interoperability, and independent `sipsorcery/webrtc-interop` matrices.
 - **Inspectable and extensible** — instrument RTP/RTCP, experiment with congestion logic, inspect transport state, or modify protocol behavior without crossing a native boundary.
 
 ## Install
@@ -186,11 +186,13 @@ The top-level `werift` package also exports lower-level WebRTC transport and RTP
 
 ## Interoperability
 
-Interoperability is tested at more than one level.
+Interoperability is validated at more than one level.
 
-### Browser E2E
+### Browser interoperability
 
 The repository contains browser E2E tooling and Chromium-focused coverage, including scenarios for ICE-Lite, ICE-TCP, and TURN relay over UDP/TCP/TLS. A Firefox test runner is also included in the E2E workspace.
+
+**Safari interoperability is community-verified.** Community users have reported using werift extensively with Safari; see [Issue #346](https://github.com/shinyoshiaki/werift-webrtc/issues/346). Safari is not currently part of the repository's automated browser E2E matrix, so this is presented as community validation rather than a CI guarantee.
 
 ### Cross-implementation matrix
 

--- a/docs/browser-api-compatibility.md
+++ b/docs/browser-api-compatibility.md
@@ -1,0 +1,49 @@
+# Browser API compatibility
+
+werift provides a browser-compatible WebRTC API for Node.js. Applications can use familiar browser WebRTC primitives such as `RTCPeerConnection`, `MediaStreamTrack`, `RTCDataChannel`, offer/answer negotiation, ICE candidates, transceivers, standard events, and `getStats()` while retaining access to werift's lower-level protocol APIs.
+
+The implementation tracks the W3C WebRTC API closely and is exercised with an allowlisted upstream Web Platform Tests (WPT) runner. This document records the remaining intentional or known differences from browser behavior so the main README can describe the normal API surface without mixing it with edge-case compatibility details.
+
+## Remaining differences
+
+| Area | werift behavior | Browser / W3C behavior | Reason / status |
+| --- | --- | --- | --- |
+| `addIceCandidate()` before `remoteDescription` | Candidates are buffered and applied after `setRemoteDescription()` | The spec rejects this ordering | Preserved for backward compatibility. The WPT runner applies a strict shim where required. |
+| `bundlePolicy: "balanced"` | Accepted, then normalized to werift's `"max-compat"` behavior; `getConfiguration()` returns `"max-compat"` | Browsers preserve `"balanced"` | Compatibility input is accepted, but the internal transport model currently uses werift's existing policy. |
+| `iceCandidatePoolSize` | `0` is supported; values greater than `0` are rejected | Browsers may support candidate pooling | Candidate pooling is not implemented. |
+| `RTCPeerConnection.close()` | Async for historical API compatibility | Browser API is synchronous and returns `undefined` | Intentional backward-compatible return-type difference. |
+| `setLocalDescription()` | Non-rollback calls return the applied `SessionDescription` | Browser API resolves `Promise<void>` | Intentional backward-compatible return-type difference. The rollback path resolves with `undefined`. |
+| `RTCPeerConnection.generateCertificate()` | Not implemented as the static browser helper | Defined by the browser API | `RTCCertificate` and `RTCConfiguration.certificates` are supported directly. |
+| Legacy callback overloads | Not implemented | Legacy browser forms exist historically | Intentionally out of scope. Promise-based APIs are supported. |
+| `addStream`, `removeStream`, `createDTMFSender` | Not implemented | Obsolete/legacy browser APIs | Intentionally out of scope; use track, transceiver, and sender APIs instead. |
+
+## Browser-compatible surface
+
+The normal application-facing surface includes:
+
+- `RTCPeerConnection` offer/answer negotiation
+- `setLocalDescription()` / `setRemoteDescription()` including implicit description generation and rollback/pranswer handling
+- `currentLocalDescription`, `pendingLocalDescription`, `currentRemoteDescription`, and `pendingRemoteDescription`
+- `addIceCandidate()`, end-of-candidates handling, and ICE server URL arrays
+- `RTCConfiguration` fields including `iceServers`, `iceTransportPolicy`, `bundlePolicy`, `rtcpMuxPolicy`, `iceCandidatePoolSize`, and `certificates`
+- `canTrickleIceCandidates` and `sctp`
+- tracks, senders, receivers, and transceivers
+- `RTCDataChannel` with browser-style event handlers
+- standard event names through `addEventListener()` / `removeEventListener()`
+- `getStats()` reports for RTP, transport, ICE candidates and candidate pairs, codecs, certificates, DataChannels, and related objects
+
+## WPT strategy
+
+werift includes an allowlisted upstream WPT runner under `packages/webrtc`. The default public API keeps backward-compatible werift behavior where changing it would be unnecessarily disruptive, while the WPT tooling can apply strict compatibility shims for test cases that require exact browser ordering or error behavior.
+
+Initialize the WPT submodule before running the compatibility suite:
+
+```sh
+git submodule update --init --recursive
+npm run wpt --workspace packages/webrtc
+npm run wpt:coverage --workspace packages/webrtc
+```
+
+## Interoperability is separate from API shape
+
+Browser API compatibility describes the JavaScript/TypeScript interface. Wire-level interoperability is validated separately through repository browser E2E tests, community Safari reports, and the independent [`sipsorcery/webrtc-interop`](https://github.com/sipsorcery/webrtc-interop) matrices.

--- a/packages/webrtc/README.md
+++ b/packages/webrtc/README.md
@@ -84,7 +84,9 @@ See the [repository README](../../README.md#protocol-coverage-at-a-glance) for t
 
 ## Interoperability
 
-The repository contains Chromium-focused browser E2E tests and a Firefox test runner. werift also participates in the independent [`sipsorcery/webrtc-interop`](https://github.com/sipsorcery/webrtc-interop) Peer Connection and Data Channel Echo matrices.
+The repository contains Chromium-focused browser E2E tests and a Firefox test runner. Safari interoperability is also community-verified: users have reported extensive real-world use with Safari in [Issue #346](https://github.com/shinyoshiaki/werift-webrtc/issues/346). Safari is not currently part of the automated browser E2E matrix, so this is community validation rather than a CI guarantee.
+
+werift also participates in the independent [`sipsorcery/webrtc-interop`](https://github.com/sipsorcery/webrtc-interop) Peer Connection and Data Channel Echo matrices.
 
 ## RTCPeerConnection W3C compatibility notes
 

--- a/packages/webrtc/README.md
+++ b/packages/webrtc/README.md
@@ -1,12 +1,14 @@
 # werift
 
-werift (**We**b**r**tc **I**mplementation **f**or **T**ypeScript)
+werift (**We**b**R**TC **I**mplementation **f**or **T**ypeScript) is a WebRTC implementation for Node.js written in TypeScript.
 
-werift is a WebRTC Implementation for TypeScript (Node.js)
+For the project overview, current features, examples, architecture, and interoperability information, see the [repository README](../../README.md).
 
-# install
+## Install
 
-`npm install werift`
+```sh
+npm install werift
+```
 
 ## Development setup
 
@@ -30,133 +32,100 @@ npm run wpt --workspace packages/webrtc -- --update-baseline
 WPT_UPDATE_COVERAGE_BASELINE=1 npm run wpt:coverage --workspace packages/webrtc
 ```
 
-# Documentation (WIP)
+## Documentation
 
 - [Website](https://shinyoshiaki.github.io/werift-webrtc/website/build/)
 - [API Reference](https://shinyoshiaki.github.io/werift-webrtc/website/build/docs/api)
+- [Examples](../../examples)
 
-# examples
+## Demos
 
-https://github.com/shinyoshiaki/werift-webrtc/tree/master/examples
+### MediaChannel
 
-### SFU
-
-https://github.com/shinyoshiaki/node-sfu
-
-# demo
-
-## MediaChannel
+From the repository root:
 
 ```sh
-yarn media
+npm run media
 ```
 
-open
+Open:
+
 https://shinyoshiaki.github.io/werift-webrtc/examples/mediachannel/pubsub/answer
 
-see console & chrome://webrtc-internals/
+Use the browser console and `chrome://webrtc-internals/` for inspection.
 
-## DataChannel
+### DataChannel
 
-run
+From the repository root:
 
 ```sh
-yarn datachannel
+npm run datachannel
 ```
 
-open
+Open:
+
 https://shinyoshiaki.github.io/werift-webrtc/examples/datachannel/answer
 
-see console & chrome://webrtc-internals/
+## Current implementation highlights
 
-# RoadMap
+- STUN and TURN relay support, including TURN control transports over UDP, TCP, and TLS
+- Full ICE, trickle ICE, ICE-Lite support/interoperability, ICE restart, and ICE-TCP
+- DTLS-SRTP, SRTP, and SRTCP
+- DataChannel over SCTP/DTLS
+- Media sendonly / recvonly / sendrecv and multiple tracks
+- RTP/RTCP feedback including SR/RR, PLI, REMB, Generic NACK, and Transport-Wide CC
+- RTX and RED
+- Receive-side simulcast
+- Sender-side bandwidth estimation
+- W3C-oriented `getStats()` reporting
+- W3C compatibility work backed by an allowlisted upstream WPT runner
 
-## Work in Progress Towards 1.0
+See the [repository README](../../README.md#protocol-coverage-at-a-glance) for the broader feature checklist.
 
-- [x] STUN
-- [x] TURN
-  - [x] UDP
-- [x] ICE
-  - [x] Vanilla ICE
-  - [x] Trickle ICE
-- [x] DTLS
-  - [x] DTLS-SRTP
-  - [x] Curve25519
-  - [x] P-256
-- [x] DataChannel
-- [x] MediaChannel
-  - [x] sendonly
-  - [x] recvonly
-  - [x] sendrecv
-  - [x] multi track
-- [x] RTP
-- [x] RTCP
-  - [x] SR/RR
-  - [x] Picture Loss Indication
-  - [x] ReceiverEstimatedMaxBitrate
-  - [x] GenericNack
-  - [x] TransportWideCC
-- [x] SRTP
-- [x] SRTCP
-- [x] SDP
-- [x] PeerConnection
-- [x] Simulcast
-  - [x] recv
-- [x] BWE
-  - [x] sender side BWE
-- [ ] Documentation
-- [x] Compatibility
-  - [x] Chrome
-  - [x] FireFox
-  - [x] Pion
-  - [x] aiortc
-  - [x] sipsorcery
-- [x] Interop E2E test
-  - [x] Chrome
-  - ↓↓↓ https://github.com/sipsorcery/webrtc-echoes
-  - [x] Pion
-  - [x] aiortc
-  - [x] sipsorcery
-- [ ] Unit Tests
-  - [ ] follow [Web Platform Tests](https://github.com/web-platform-tests/wpt)
+## Interoperability
 
-## Road Map Towards 2.0
-
-- [ ] API compatible with browser RTCPeerConnection
-- [ ] ICE
-  - [ ] ICE restart
-- [ ] SDP
-  - [ ] reuse inactive m-line
-- [ ] Simulcast
-  - [ ] send
-- [ ] support more cipher suites
+The repository contains Chromium-focused browser E2E tests and a Firefox test runner. werift also participates in the independent [`sipsorcery/webrtc-interop`](https://github.com/sipsorcery/webrtc-interop) Peer Connection and Data Channel Echo matrices.
 
 ## RTCPeerConnection W3C compatibility notes
 
-API reference markdown can be regenerated with `cd packages/webrtc && npm run doc`.
-For this task, the reviewable compatibility notes live in this README and in
-`src/peerConnection.ts`; the generated `packages/webrtc/doc/` output is not
-tracked in git, so it is not committed as part of this change.
+API reference markdown can be regenerated with:
+
+```sh
+cd packages/webrtc && npm run doc
+```
+
+The implementation intentionally keeps some historical werift behavior where changing it would be backward-incompatible. The WPT runner can apply stricter compatibility shims where noted.
 
 | Status | API | Notes |
 | --- | --- | --- |
-| Added | `currentLocalDescription`, `pendingLocalDescription`, `currentRemoteDescription`, `pendingRemoteDescription`, `canTrickleIceCandidates`, `sctp` | Public getters now follow W3C-style pending/current description visibility and expose SCTP/canTrickle state. |
+| Added | `currentLocalDescription`, `pendingLocalDescription`, `currentRemoteDescription`, `pendingRemoteDescription`, `canTrickleIceCandidates`, `sctp` | Public getters expose W3C-style pending/current description, SCTP, and can-trickle state. |
 | Added | `setLocalDescription()` input compatibility | Accepts omitted `type`, empty `sdp`, and provisional `pranswer`. |
 | Added | `setRemoteDescription()` input compatibility | Accepts `pranswer` and `rollback`, updating pending/current descriptions accordingly. |
-| Added | `addIceCandidate()` input compatibility | Accepts omitted input, `null`, and `{ candidate: "" }` as end-of-candidates, validates `sdpMid` / `sdpMLineIndex` / `usernameFragment`, updates the matching remote m-section, rejects calls before `remoteDescription` is set, and rejects malformed candidate strings. |
+| Added with backward-compatible difference | `addIceCandidate()` | Accepts omitted input, `null`, and `{ candidate: "" }` as end-of-candidates; validates `sdpMid` / `sdpMLineIndex` / `usernameFragment`; updates the matching remote m-section; and rejects malformed candidate strings. The public API preserves werift's historical behavior of buffering candidates received before `remoteDescription`; the WPT runner uses a strict shim where spec-style pre-SRD rejection is required. |
 | Added | `RTCConfiguration` compatibility | Accepts `iceServers`, `iceTransportPolicy`, `bundlePolicy`, `rtcpMuxPolicy: "require"`, `iceCandidatePoolSize: 0`, and `certificates`; `setConfiguration(getConfiguration())` round-trips without changing certificates. |
-| Deferred | `bundlePolicy: "balanced"` round-trip | `"balanced"` is accepted for input compatibility, but it is internally normalized to werift's `"max-compat"` behavior, so `getConfiguration()` returns `"max-compat"`. |
+| Deferred | `bundlePolicy: "balanced"` round-trip | `"balanced"` is accepted for input compatibility but normalized to werift's `"max-compat"` behavior, so `getConfiguration()` returns `"max-compat"`. |
 | Added | `RTCIceServer.urls: string \| string[]` | Arrays are accepted and parsed in order. |
 | Added | Standard event names | `signalingstatechange`, `iceconnectionstatechange`, `icegatheringstatechange`, `connectionstatechange`, `negotiationneeded`, `icecandidate`, `track`, and `datachannel` are emitted for `addEventListener`. |
-| Not implemented | Legacy callback overloads | Kept out of scope because they are legacy browser APIs. |
-| Not implemented | `addStream`, `removeStream`, `createDTMFSender` | These are obsolete; use `addTrack`, `removeTrack`, and transceiver/sender APIs instead. |
-| Deferred | `close()` return type | Remains async for backward compatibility even though W3C defines synchronous `undefined`. |
-| Deferred | `setLocalDescription()` return type | Non-rollback calls still return the applied `SessionDescription` instead of `Promise<void>` for backward compatibility; the local `rollback` path resolves with `undefined`. |
-| Compatible | `setRemoteDescription()` return type | `setRemoteDescription()` resolves `Promise<void>` like the W3C API. |
-| Deferred | `RTCPeerConnection.generateCertificate()` | `RTCCertificate` and `RTCConfiguration.certificates` are supported, but the static W3C helper is still optional work. |
+| Not implemented | Legacy callback overloads | Intentionally out of scope as legacy browser APIs. |
+| Not implemented | `addStream`, `removeStream`, `createDTMFSender` | Obsolete APIs; use track/transceiver/sender APIs instead. |
+| Deferred | `close()` return type | Remains async for backward compatibility even though the W3C API is synchronous. |
+| Deferred | `setLocalDescription()` return type | Non-rollback calls still return the applied `SessionDescription` instead of `Promise<void>` for backward compatibility; local rollback resolves with `undefined`. |
+| Compatible | `setRemoteDescription()` return type | Resolves `Promise<void>` like the W3C API. |
+| Deferred | `RTCPeerConnection.generateCertificate()` | `RTCCertificate` and `RTCConfiguration.certificates` are supported, but the static W3C helper is not implemented. |
 
-# reference
+## Roadmap
 
-- aiortc https://github.com/aiortc/aiortc
-- pion/webrtc https://github.com/pion/webrtc
-- etc ....
+Current work is focused on:
+
+- improving documentation and WPT coverage
+- closing remaining browser `RTCPeerConnection` API compatibility gaps
+- simulcast send support
+- additional cipher suites
+- richer WebRTC statistics coverage
+- continued unit, E2E, interoperability, and long-running reliability testing
+
+## References
+
+- [aiortc](https://github.com/aiortc/aiortc)
+- [Pion WebRTC](https://github.com/pion/webrtc)
+- [sipsorcery/webrtc-interop](https://github.com/sipsorcery/webrtc-interop)

--- a/packages/webrtc/README.md
+++ b/packages/webrtc/README.md
@@ -1,6 +1,6 @@
 # werift
 
-werift (**We**b**R**TC **I**mplementation **f**or **T**ypeScript) is a WebRTC implementation for Node.js written in TypeScript.
+werift (**We**b**R**TC **I**mplementation **f**or **T**ypeScript) is a WebRTC implementation for Node.js written in TypeScript with a browser-compatible WebRTC API.
 
 For the project overview, current features, examples, architecture, and interoperability information, see the [repository README](../../README.md).
 
@@ -9,6 +9,12 @@ For the project overview, current features, examples, architecture, and interope
 ```sh
 npm install werift
 ```
+
+## Browser-compatible WebRTC API
+
+werift is designed so application code can use the familiar browser WebRTC model in Node.js: `RTCPeerConnection`, tracks and transceivers, `RTCDataChannel`, standard events, ICE configuration, offer/answer negotiation, and `getStats()`.
+
+A small number of intentional or known edge-case differences remain for backward compatibility or unsupported legacy APIs. See [Browser API compatibility](../../docs/browser-api-compatibility.md) for those differences and the WPT strategy used to track exact browser behavior.
 
 ## Development setup
 
@@ -37,6 +43,7 @@ WPT_UPDATE_COVERAGE_BASELINE=1 npm run wpt:coverage --workspace packages/webrtc
 - [Website](https://shinyoshiaki.github.io/werift-webrtc/website/build/)
 - [API Reference](https://shinyoshiaki.github.io/werift-webrtc/website/build/docs/api)
 - [Examples](../../examples)
+- [Browser API compatibility differences](../../docs/browser-api-compatibility.md)
 
 ## Demos
 
@@ -68,6 +75,7 @@ https://shinyoshiaki.github.io/werift-webrtc/examples/datachannel/answer
 
 ## Current implementation highlights
 
+- Browser-compatible `RTCPeerConnection` API and standard WebRTC events
 - STUN and TURN relay support, including TURN control transports over UDP, TCP, and TLS
 - Full ICE, trickle ICE, ICE-Lite support/interoperability, ICE restart, and ICE-TCP
 - DTLS-SRTP, SRTP, and SRTCP
@@ -77,8 +85,8 @@ https://shinyoshiaki.github.io/werift-webrtc/examples/datachannel/answer
 - RTX and RED
 - Receive-side simulcast
 - Sender-side bandwidth estimation
-- W3C-oriented `getStats()` reporting
-- W3C compatibility work backed by an allowlisted upstream WPT runner
+- Browser-compatible `getStats()` reporting
+- Compatibility validation backed by an allowlisted upstream WPT runner
 
 See the [repository README](../../README.md#protocol-coverage-at-a-glance) for the broader feature checklist.
 
@@ -88,39 +96,12 @@ The repository contains Chromium-focused browser E2E tests and a Firefox test ru
 
 werift also participates in the independent [`sipsorcery/webrtc-interop`](https://github.com/sipsorcery/webrtc-interop) Peer Connection and Data Channel Echo matrices.
 
-## RTCPeerConnection W3C compatibility notes
-
-API reference markdown can be regenerated with:
-
-```sh
-cd packages/webrtc && npm run doc
-```
-
-The implementation intentionally keeps some historical werift behavior where changing it would be backward-incompatible. The WPT runner can apply stricter compatibility shims where noted.
-
-| Status | API | Notes |
-| --- | --- | --- |
-| Added | `currentLocalDescription`, `pendingLocalDescription`, `currentRemoteDescription`, `pendingRemoteDescription`, `canTrickleIceCandidates`, `sctp` | Public getters expose W3C-style pending/current description, SCTP, and can-trickle state. |
-| Added | `setLocalDescription()` input compatibility | Accepts omitted `type`, empty `sdp`, and provisional `pranswer`. |
-| Added | `setRemoteDescription()` input compatibility | Accepts `pranswer` and `rollback`, updating pending/current descriptions accordingly. |
-| Added with backward-compatible difference | `addIceCandidate()` | Accepts omitted input, `null`, and `{ candidate: "" }` as end-of-candidates; validates `sdpMid` / `sdpMLineIndex` / `usernameFragment`; updates the matching remote m-section; and rejects malformed candidate strings. The public API preserves werift's historical behavior of buffering candidates received before `remoteDescription`; the WPT runner uses a strict shim where spec-style pre-SRD rejection is required. |
-| Added | `RTCConfiguration` compatibility | Accepts `iceServers`, `iceTransportPolicy`, `bundlePolicy`, `rtcpMuxPolicy: "require"`, `iceCandidatePoolSize: 0`, and `certificates`; `setConfiguration(getConfiguration())` round-trips without changing certificates. |
-| Deferred | `bundlePolicy: "balanced"` round-trip | `"balanced"` is accepted for input compatibility but normalized to werift's `"max-compat"` behavior, so `getConfiguration()` returns `"max-compat"`. |
-| Added | `RTCIceServer.urls: string \| string[]` | Arrays are accepted and parsed in order. |
-| Added | Standard event names | `signalingstatechange`, `iceconnectionstatechange`, `icegatheringstatechange`, `connectionstatechange`, `negotiationneeded`, `icecandidate`, `track`, and `datachannel` are emitted for `addEventListener`. |
-| Not implemented | Legacy callback overloads | Intentionally out of scope as legacy browser APIs. |
-| Not implemented | `addStream`, `removeStream`, `createDTMFSender` | Obsolete APIs; use track/transceiver/sender APIs instead. |
-| Deferred | `close()` return type | Remains async for backward compatibility even though the W3C API is synchronous. |
-| Deferred | `setLocalDescription()` return type | Non-rollback calls still return the applied `SessionDescription` instead of `Promise<void>` for backward compatibility; local rollback resolves with `undefined`. |
-| Compatible | `setRemoteDescription()` return type | Resolves `Promise<void>` like the W3C API. |
-| Deferred | `RTCPeerConnection.generateCertificate()` | `RTCCertificate` and `RTCConfiguration.certificates` are supported, but the static W3C helper is not implemented. |
-
 ## Roadmap
 
 Current work is focused on:
 
 - improving documentation and WPT coverage
-- closing remaining browser `RTCPeerConnection` API compatibility gaps
+- closing remaining documented browser API edge-case differences
 - simulcast send support
 - additional cipher suites
 - richer WebRTC statistics coverage


### PR DESCRIPTION
## What changed

- Reworked the root README into a product-oriented introduction centered on werift itself.
- Presents werift's application-facing surface simply as a **browser-compatible WebRTC API** for Node.js.
- Added a browser-style DataChannel quick start and concise browser API section.
- Emphasized TypeScript protocol access, packet-oriented media control, modular protocol packages, modern ICE/TURN connectivity, and interoperability evidence.
- Added a transport architecture diagram that correctly separates DTLS-SRTP keying from the SRTP media path.
- Added an evidence-backed feature matrix covering ICE-Lite, ICE-TCP, TURN over UDP/TCP/TLS, browser-compatible PeerConnection APIs and stats, sender-side BWE, recording, nonstandard media helpers, and RTP processing.
- Added `werift-ice-server` to the modular package overview.
- Updated interoperability references to `sipsorcery/webrtc-interop` and documented Safari as **community-verified interoperability** based on Issue #346, while distinguishing it from automated browser E2E coverage.
- Removed direct references to comparison projects from the README so the document stands on werift's own capabilities.

## Browser API compatibility structure

Browser compatibility is now treated as the normal user-facing API rather than as a large unfinished compatibility section:

- `README.md`: concise **browser-compatible WebRTC API** positioning and usage.
- `packages/webrtc/README.md`: concise package-level API description.
- `docs/browser-api-compatibility.md`: remaining intentional/known differences and WPT details.

The dedicated compatibility document records edge cases such as pre-SRD `addIceCandidate()` buffering, `bundlePolicy: "balanced"` normalization, `iceCandidatePoolSize > 0`, historical return-type differences, and unsupported legacy/obsolete APIs.

## Accuracy corrections

The README was source-reviewed against the current implementation. Corrections include:

- distinguishing the packet-oriented core API from optional `werift/nonstandard` MP4/WebM playback, configurable/dummy media sources, and recording helpers;
- correcting the DTLS/SRTP architecture so SRTP media is shown on the ICE path rather than tunneled through DTLS;
- documenting the public pre-SRD `addIceCandidate()` buffering behavior accurately;
- clarifying TURN UDP/TCP/TLS control transports and `turn:` / `turns:` handling;
- describing sender-side bandwidth estimation as Transport-Wide-CC-driven;
- distinguishing Chromium automated E2E, the Firefox test runner, and community-reported Safari interoperability.

## Validation sources

Claims were cross-checked against the current `develop` implementation and documentation, including:

- `packages/webrtc/src/peerConnection.ts`
- `packages/webrtc/src/helper.ts`
- `packages/webrtc/src/dataChannel.ts`
- `packages/webrtc/src/transport/dtls.ts`
- `packages/webrtc/src/media/stats.ts`
- `packages/webrtc/src/media/sender/senderBWE.ts`
- `packages/webrtc/src/nonstandard/userMedia.ts`
- `packages/webrtc/src/nonstandard/navigator.ts`
- `packages/webrtc/src/nonstandard/recorder/*`
- `packages/ice/src/turn/protocol.ts`
- `packages/ice-server/README.md`
- `changelog.md` (v0.24.x)
- Issue #346 community Safari compatibility report
- current `sipsorcery/webrtc-interop` matrices

The diff is documentation-only: `README.md`, `packages/webrtc/README.md`, and `docs/browser-api-compatibility.md`.