### PR TITLE
feat(ice): two ICE gathering options for send-only agents

### DIFF
--- a/packages/ice/src/ice.ts
+++ b/packages/ice/src/ice.ts
@@ -226,7 +226,10 @@ export class Connection implements IceConnection {
         );
       }
 
-      const candidatePromises = this.getCandidatePromises(address, 5);
+      const candidatePromises = this.getCandidatePromises(
+        address,
+        this.options.stunGatherTimeout,
+      );
       await Promise.allSettled(candidatePromises);
 
       this.localCandidatesEnd = true;

--- a/packages/ice/src/ice.ts
+++ b/packages/ice/src/ice.ts
@@ -400,29 +400,34 @@ export class Connection implements IceConnection {
 
     if (!gatherRelayOnly && this.options.useTcp) {
       const tcpCandidatePromises = addresses.map(async (address) => {
-        const passiveProtocol = new TcpPassiveProtocol();
-        this.ensureProtocol(passiveProtocol);
-        await passiveProtocol.connectionMade(address, this.options.portRange);
-        passiveProtocol.localIp = address;
-        passiveProtocol.localCandidate = new Candidate(
-          candidateFoundation("host", "tcp", address),
-          1,
-          "tcp",
-          candidatePriority("host", {
-            transport: "tcp",
-            tcptype: "passive",
-          }),
-          address,
-          passiveProtocol.listeningPort,
-          "host",
-          undefined,
-          undefined,
-          "passive",
-          this.generation,
-          this.localUsername,
-        );
-        this.protocols.push(passiveProtocol);
-        this.appendLocalCandidate(passiveProtocol.localCandidate);
+        // Passive candidates open a listening TCP server; skip them when the
+        // agent only makes outbound connections (tcpPassive === false). Active
+        // candidates below still dial out, so direct TCP egress is unaffected.
+        if (this.options.tcpPassive !== false) {
+          const passiveProtocol = new TcpPassiveProtocol();
+          this.ensureProtocol(passiveProtocol);
+          await passiveProtocol.connectionMade(address, this.options.portRange);
+          passiveProtocol.localIp = address;
+          passiveProtocol.localCandidate = new Candidate(
+            candidateFoundation("host", "tcp", address),
+            1,
+            "tcp",
+            candidatePriority("host", {
+              transport: "tcp",
+              tcptype: "passive",
+            }),
+            address,
+            passiveProtocol.listeningPort,
+            "host",
+            undefined,
+            undefined,
+            "passive",
+            this.generation,
+            this.localUsername,
+          );
+          this.protocols.push(passiveProtocol);
+          this.appendLocalCandidate(passiveProtocol.localCandidate);
+        }
 
         if (!gatherIceLite) {
           const activeProtocol = new TcpActiveProtocol();

--- a/packages/ice/src/iceBase.ts
+++ b/packages/ice/src/iceBase.ts
@@ -232,6 +232,13 @@ export interface IceOptions {
   /** Advertise and operate as an ICE lite agent. */
   iceLite: boolean;
   useTcp: boolean;
+  /**
+   * Gather passive TCP host candidates (opens a listening TCP server per
+   * interface). Defaults to true. Send-only agents that never accept inbound
+   * connections can set this false to avoid the listener while still gathering
+   * active TCP candidates.
+   */
+  tcpPassive?: boolean;
   stunServer?: Address;
   turnServer?: Address;
   turnUsername?: string;

--- a/packages/ice/src/iceBase.ts
+++ b/packages/ice/src/iceBase.ts
@@ -239,6 +239,13 @@ export interface IceOptions {
    * active TCP candidates.
    */
   tcpPassive?: boolean;
+  /**
+   * Seconds to wait for server-reflexive candidates while gathering.
+   * Defaults to 5. Where UDP is blocked these STUN queries are never answered,
+   * so the wait always runs to the timeout; agents that must not stall on such
+   * networks can lower it.
+   */
+  stunGatherTimeout?: number;
   stunServer?: Address;
   turnServer?: Address;
   turnUsername?: string;

--- a/packages/webrtc/src/peerConnection.ts
+++ b/packages/webrtc/src/peerConnection.ts
@@ -1288,6 +1288,11 @@ export interface PeerConfig {
   iceUseTcp: boolean;
   /** Gather passive (listening) TCP host candidates. Defaults to true. */
   iceTcpPassive: boolean;
+  /**
+   * Seconds to wait for server-reflexive candidates while gathering.
+   * Defaults to 5 when undefined.
+   */
+  iceStunGatherTimeout: number | undefined;
   turnTransport: "udp" | "tcp" | "tls" | undefined;
   turnTlsOptions: TlsConnectionOptions | undefined;
   /** @deprecated Prefer turn URL transport parameters or turnTransport. */
@@ -1383,6 +1388,7 @@ function generateDefaultPeerConfig(): PeerConfig {
     iceUseIpv6: true,
     iceUseTcp: false,
     iceTcpPassive: true,
+    iceStunGatherTimeout: undefined,
     turnTransport: undefined,
     turnTlsOptions: undefined,
     iceFilterStunResponse: undefined,

--- a/packages/webrtc/src/peerConnection.ts
+++ b/packages/webrtc/src/peerConnection.ts
@@ -1286,6 +1286,8 @@ export interface PeerConfig {
   iceUseIpv4: boolean;
   iceUseIpv6: boolean;
   iceUseTcp: boolean;
+  /** Gather passive (listening) TCP host candidates. Defaults to true. */
+  iceTcpPassive: boolean;
   turnTransport: "udp" | "tcp" | "tls" | undefined;
   turnTlsOptions: TlsConnectionOptions | undefined;
   /** @deprecated Prefer turn URL transport parameters or turnTransport. */
@@ -1380,6 +1382,7 @@ function generateDefaultPeerConfig(): PeerConfig {
     iceUseIpv4: true,
     iceUseIpv6: true,
     iceUseTcp: false,
+    iceTcpPassive: true,
     turnTransport: undefined,
     turnTlsOptions: undefined,
     iceFilterStunResponse: undefined,

--- a/packages/webrtc/src/secureTransportManager.ts
+++ b/packages/webrtc/src/secureTransportManager.ts
@@ -115,6 +115,7 @@ export class SecureTransportManager {
       useIpv6: this.config.iceUseIpv6,
       useTcp: this.config.iceUseTcp,
       turnTransport,
+      tcpPassive: this.config.iceTcpPassive,
       turnTlsOptions: this.config.turnTlsOptions,
       useLinkLocalAddress: this.config.iceUseLinkLocalAddress,
     });

--- a/packages/webrtc/src/secureTransportManager.ts
+++ b/packages/webrtc/src/secureTransportManager.ts
@@ -116,6 +116,7 @@ export class SecureTransportManager {
       useTcp: this.config.iceUseTcp,
       turnTransport,
       tcpPassive: this.config.iceTcpPassive,
+      stunGatherTimeout: this.config.iceStunGatherTimeout,
       turnTlsOptions: this.config.turnTlsOptions,
       useLinkLocalAddress: this.config.iceUseLinkLocalAddress,
     });


### PR DESCRIPTION
# Two ICE gathering options for send-only agents

Both options are opt-in and keep the current behaviour as the default.

## tcpPassive

`useTcp` gathers passive and active TCP host candidates. The passive ones open a listening TCP
server on every selected interface. An agent that only dials out never accepts a connection on
them, and on Windows they cost an inbound firewall rule to gather at all.

`tcpPassive` on `IceOptions`, `iceTcpPassive` on `RTCPeerConnection`, defaults to `true`. Set it
to `false` and only the passive candidates are skipped. Active TCP is still gathered, so outbound
TCP including TURN over TCP works as before.

```ts
const pc = new RTCPeerConnection({
  iceUseTcp: true,
  iceTcpPassive: false,
});
```

## stunGatherTimeout

`gather()` waits up to 5 seconds for the server-reflexive candidates. Where UDP is blocked those
STUN queries are never answered, so the wait always runs to the full timeout. With non-trickle
signalling the offer cannot be sent until gathering finishes, and those 5 seconds land in every
session setup. WHIP again.

`stunGatherTimeout` on `IceOptions`, `iceStunGatherTimeout` on `RTCPeerConnection`, takes seconds
and is undefined by default, which leaves the current 5 seconds in place. The
`getCandidatePromises` default is untouched.

```ts
const pc = new RTCPeerConnection({
  iceStunGatherTimeout: 1.5,
});
```

## Testing

From a network with UDP egress blocked: with `iceStunGatherTimeout: 1.5` the gather finishes in
about 1.5 seconds instead of 5, and with `iceTcpPassive: false` no TCP listener is opened while
the active TCP and TURN/TCP candidates still connect. Existing test suites pass.