### PR TITLE
feat(webrtc): apply ICE server updates to a gatherer that has not gathered yet

### DIFF
--- a/packages/ice/src/ice.ts
+++ b/packages/ice/src/ice.ts
@@ -102,6 +102,24 @@ export class Connection implements IceConnection {
     log("new Connection", this.options);
   }
 
+  /**
+   * Update STUN/TURN servers after construction but before gathering.
+   * The gatherer captures ICE servers when it is built (at createOffer time),
+   * yet a relay candidate can only be gathered if TURN is known before the
+   * single gather pass. This lets servers learned later (e.g. from a WHIP
+   * Link header) be applied before setLocalDescription triggers gathering.
+   */
+  setIceServers(options: Partial<IceOptions>) {
+    this.options = { ...this.options, ...options };
+    const { stunServer, turnServer } = this.options;
+    this.stunServer = validateAddress(stunServer) ?? [
+      "stun.l.google.com",
+      19302,
+    ];
+    this.turnServer = validateAddress(turnServer);
+    log("Connection ice servers updated", this.options);
+  }
+
   get iceControlling() {
     return this._iceControlling;
   }

--- a/packages/ice/src/iceBase.ts
+++ b/packages/ice/src/iceBase.ts
@@ -43,6 +43,8 @@ export interface IceConnection {
 
   restart(): void;
 
+  setIceServers(options: Partial<IceOptions>): void;
+
   setRemoteParams(params: {
     iceLite: boolean;
     usernameFragment: string;

--- a/packages/webrtc/src/peerConnection.ts
+++ b/packages/webrtc/src/peerConnection.ts
@@ -475,6 +475,19 @@ export class RTCPeerConnection extends EventTarget {
     ].forEach((v, i) => {
       v.id = 1 + i;
     });
+
+    // Propagate ICE server changes to a transport that already exists but has
+    // not gathered yet. werift binds ICE servers when the gatherer is built
+    // (at createOffer); this lets TURN learned afterwards (e.g. from a WHIP
+    // Link header) take effect before setLocalDescription triggers gathering.
+    if (
+      isReconfiguration &&
+      this.secureManager &&
+      normalizedConfig.iceServers !== undefined &&
+      this.secureManager.iceGatheringState === "new"
+    ) {
+      this.secureManager.updateIceServers();
+    }
   }
 
   getConfiguration() {

--- a/packages/webrtc/src/secureTransportManager.ts
+++ b/packages/webrtc/src/secureTransportManager.ts
@@ -90,19 +90,39 @@ export class SecureTransportManager {
     );
   }
 
-  createTransport() {
-    const existing = this.iceTransports.find(
-      (transport) => transport.state !== "closed",
-    );
+  private resolveIceServerOptions() {
     const iceServerOptions = parseIceServers(this.config.iceServers);
     const turnTransport = resolveTurnTransport({
       parsedTurnTransport: iceServerOptions.turnTransport,
       configuredTurnTransport: this.config.turnTransport,
       forceTurnTCP: this.config.forceTurnTCP,
     });
+    return { ...iceServerOptions, turnTransport };
+  }
+
+  /**
+   * Re-apply ICE servers from the current config to every live ICE transport.
+   * Used when TURN is learned after the gatherer was built (e.g. from a WHIP
+   * Link header) so the next gather pass can produce a relay candidate.
+   */
+  updateIceServers() {
+    const options = {
+      ...this.resolveIceServerOptions(),
+      forceTurn: this.config.iceTransportPolicy === "relay",
+      useTcp: this.config.iceUseTcp,
+    };
+    for (const iceTransport of this.iceTransports) {
+      iceTransport.setIceServers(options);
+    }
+  }
+
+  createTransport() {
+    const existing = this.iceTransports.find(
+      (transport) => transport.state !== "closed",
+    );
 
     const iceGatherer = new RTCIceGatherer({
-      ...iceServerOptions,
+      ...this.resolveIceServerOptions(),
       iceLite: this.config.iceLite,
       forceTurn: this.config.iceTransportPolicy === "relay",
       portRange: this.config.icePortRange,
@@ -114,7 +134,6 @@ export class SecureTransportManager {
       useIpv4: this.config.iceUseIpv4,
       useIpv6: this.config.iceUseIpv6,
       useTcp: this.config.iceUseTcp,
-      turnTransport,
       turnTlsOptions: this.config.turnTlsOptions,
       useLinkLocalAddress: this.config.iceUseLinkLocalAddress,
     });

--- a/packages/webrtc/src/transport/ice.ts
+++ b/packages/webrtc/src/transport/ice.ts
@@ -182,6 +182,10 @@ export class RTCIceTransport {
     return this.iceGather.gather();
   }
 
+  setIceServers(options: Partial<IceOptions>) {
+    this.iceGather.setIceServers(options);
+  }
+
   addRemoteCandidate = (candidate?: IceCandidate) => {
     if (!this.connection.remoteCandidatesEnd) {
       return !candidate
@@ -386,6 +390,10 @@ export class RTCIceGatherer {
       this.onIceCandidate(undefined);
       this.setState("complete");
     }
+  }
+
+  setIceServers(options: Partial<IceOptions>) {
+    this.connection.setIceServers(options);
   }
 
   get localCandidates() {


### PR DESCRIPTION
# Apply ICE server updates to a gatherer that has not gathered yet

An ICE gatherer takes its STUN/TURN servers when it is constructed, and that happens on the first
`createOffer()` / `addTrack()`. A later `setConfiguration()` only writes to `PeerConfig`, so
servers set after that point never reach the gatherer and the gather pass produces no relay
candidate. The only way around it today is to build a new `RTCPeerConnection`, which throws away
the offer and its ICE credentials.

This comes up with WHIP. The endpoint returns its STUN/TURN servers in `Link` headers on the
response to the POST that carries the offer
([RFC 9725 §4.6](https://www.rfc-editor.org/rfc/rfc9725.html#section-4.6)), so the client cannot
know them until the offer already exists:

```
POST /whip/live
201 Created
Link: <stun:stun.example.net>; rel="ice-server"
Link: <turn:turn.example.net?transport=tcp>; rel="ice-server";
      username="user"; credential="myPassword"
```

On a network where UDP is blocked, the relay candidate from that header is the only one that can
connect, and right now it cannot be gathered at all. The same section says a client "may need to
call the setConfiguration method before calling the setLocalDescription method [...] in order to
avoid having to perform an ICE restart", and notes that some implementations do not support
updating the servers after the local offer has been created. werift is one of them.

## Changes

* `setIceServers(options)` on `IceConnection`, re-resolving `stunServer` / `turnServer` the way
  the constructor does.
* Pass-throughs on `RTCIceGatherer` and `RTCIceTransport`.
* `SecureTransportManager.updateIceServers()`. The ICE server parsing that `createTransport()`
  already did moved into `resolveIceServerOptions()`, so both paths use the same code.
* `setConfiguration()` calls it when `iceServers` was passed and the transport is still in
  gathering state `new`.

That last condition follows JSEP
([RFC 8829 §4.1.18](https://www.rfc-editor.org/rfc/rfc8829.html#section-4.1.18)): changes to the
STUN/TURN servers affect the next gathering phase. Once gathering has started or finished,
nothing is applied, so a running or completed gather cannot be disturbed. `setIceServers` is
additive on all three types.

## Usage

```ts
const pc = new RTCPeerConnection({ iceTransportPolicy: "relay" });
const offer = await pc.createOffer();

const res = await fetch(whipEndpoint, {
  method: "POST",
  headers: { "content-type": "application/sdp" },
  body: offer.sdp,
});

pc.setConfiguration({ iceServers: parseLinkHeaders(res.headers) });

await pc.setLocalDescription(offer);
```

## Testing

Ran against an OvenMediaEngine WHIP endpoint from a network with UDP egress blocked. Before the
change the gather produced host candidates only and the session never connected. After it, the
relay candidate from the `Link` header is gathered and media flows over TURN/TCP. Existing test
suites pass.
