### PR TITLE
fix(ice): cancel TURN allocation refresh lifecycle on close

### DIFF
--- a/TICKET-ticket-4485a305-442a-431b-8e8a-dd18309f62fe.md
+++ b/TICKET-ticket-4485a305-442a-431b-8e8a-dd18309f62fe.md
@@ -1,0 +1,363 @@
+Issue #685 は妥当です。2026年9月4日時点の develop HEAD 0ea9579c273607e8c9c59ca3659cdd79aeff6ad3 にも問題がそのまま残っています。Issue が指摘している「TurnProtocol.close() 後も TURN allocation refresh の timer が生存し、Node.js プロセス終了を妨げる」という主問題はコード上明確に再現します。
+
+ただし、Issue の説明には1点だけ補足があります。標準の UDP/TCP/TLS transport では、close 後に実際の REFRESH packet が wire に出る可能性は通常ありません。一方で、内部的には REFRESH transaction が開始されてしまうので、問題自体はむしろ Issue の説明より少し広いです。
+
+原因
+
+現在の refresh loop は概ね以下の構造です。
+
+let run = true;
+
+onCancel.once(() => {
+  run = false;
+});
+
+while (run) {
+  await setTimeout((5 / 6) * exp * 1000);
+
+  // run を再確認しない
+  const request = new Message(methods.REFRESH, classes.REQUEST);
+  await this.requestWithRetry(request, this.server);
+}
+
+TurnProtocol.close() が行っているのは、
+
+this.refreshHandle?.resolve?.();
+await this.transport.close();
+
+だけです。refreshHandle.resolve() → onCancel によって run=false にはなりますが、既に実行中の timers/promises.setTimeout() は cancel されません。しかも timer が満了した直後に run を再評価せず、そのまま REFRESH transaction に入ります。
+
+cancelable() 自体も executor を停止するものではなく、resolve/reject 時に onCancel event を発火するだけなので、現在の使い方では timeout を中断できません。
+
+この timer は TURN candidate が nominate されたかどうかにも依存しません。TURN server と credentials が設定されて allocation が成功すると createStunOverTurnClient() で protocol が生成されて protocols に保持され、allocation 成功時点で refresh が開始されます。Connection.close() は nominated pair に限定せず保持中の全 protocol を close します。
+
+したがって Issue の
+
+> TURN configured + allocation succeeded → relay candidate が使われなくても発生
+
+
+
+という影響範囲も正しいです。
+
+追加で判明した問題
+
+Issue の再現 transport は close() 後も closed: false のため、本当に "REFRESH sent" まで到達します。
+
+しかし werift の標準 transport は、
+
+UdpTransport.close() → closed = true
+
+StreamTransport.close() → closed = true
+
+TurnProtocol.send() → transport.closed なら return
+
+
+となっているため、通常の UDP/TCP/TLS では close 後の REFRESH は wire には出ません。
+
+ただしそこで処理が終了するわけではありません。
+
+timer 満了後には、
+
+refresh()
+  -> requestWithRetry()
+      -> request()
+          -> new Transaction()
+              -> transaction.run()
+                  -> retry()
+
+まで進みます。transport が closed なので packet は送られませんが、Transaction.retry() 自体は response を待つ timer を生成します。現在は RETRY_RTO=50ms, RETRY_MAX=6 なので、
+
+50 + 100 + 200 + 400 + 800 + 1600 + 3200
+= 6350 ms
+
+の追加 wait が発生し得ます。
+
+つまり lifetime=600 秒で allocation 直後に close した最悪ケースでは、
+
+refresh sleep        約 500.00 秒
+STUN retry timers    約   6.35 秒
+--------------------------------
+                      約 506.35 秒
+
+プロセスに timer が残る可能性があります。
+
+短命な CLI / test process / serverless worker では終了遅延になりますし、長寿命サーバーでも短時間に多数の PeerConnection を生成・破棄すると、閉じた TurnProtocol が timer closure から最大数百秒保持されるため、一時的なメモリ保持量増加につながります。
+
+そのため修正優先度は比較的高いと考えます。
+
+
+---
+
+詳細化した実装タスク
+
+Task title
+
+fix(ice): cancel TURN allocation refresh lifecycle on TurnProtocol.close() (#685)
+
+1. Refresh の sleep を Abort 可能にする
+
+対象:
+
+packages/ice/src/turn/protocol.ts
+
+refresh lifecycle ごとに AbortController を1個生成します。
+
+const abort = new AbortController();
+
+onCancel.once(() => {
+  abort.abort();
+});
+
+そして、
+
+await setTimeout(delay);
+
+を、
+
+await setTimeout(delay, undefined, {
+  signal: abort.signal,
+});
+
+へ変更します。
+
+ただし Issue に掲載されている、
+
+catch (error) {
+  return;
+}
+
+という catch-all より、
+
+catch (error) {
+  if (abort.signal.aborted) {
+    return;
+  }
+  throw error;
+}
+
+とした方が安全です。
+
+さらに timeout 正常満了と close が競合する境界を明確にするため、
+
+if (abort.signal.aborted) {
+  return;
+}
+
+を timeout 復帰直後にも入れます。
+
+{ ref: false } だけを使用する修正は不可です。process exit は可能になりますが、post-close refresh 処理そのものは残るためです。
+
+2. 同じ AbortSignal を REFRESH transaction にも伝播させる
+
+ここは Issue 提案より一段強化することを推奨します。
+
+Issue の diff は「refresh sleep 中に close」されたケースは直しますが、
+
+timeout fires
+ ↓
+REFRESH transaction starts
+ ↓
+close()
+
+というタイミングでは、既に Transaction 内の retry timer が動いているため cancel できません。
+
+幸い TransactionRequestOptions と Transaction はすでに AbortSignal を正式にサポートしており、ICE consent lifecycle でも同じ仕組みが使われています。新しいキャンセル機構を作る必要はありません。
+
+requestWithRetry() を例えば、
+
+async requestWithRetry(
+  request: Message,
+  addr: Address,
+  signal?: AbortSignal,
+)
+
+へ後方互換で拡張します。
+
+内部の両方の request()、
+
+最初の request
+401 / 438 後の retry request
+
+に必ず同じ signal を渡します。
+
+概念的には、
+
+await this.request(request, addr, undefined, {
+  signal,
+});
+
+および nonce retry でも、
+
+await this.request(request, this.server, undefined, {
+  signal,
+});
+
+とします。
+
+これにより close が REFRESH transaction 実行中に発生しても、Transaction の既存 abort path が clearTimeout() を行い、待機中の retry timer を即座に除去できます。
+
+3. Refresh loop の abort を正常終了として扱う
+
+REFRESH request の catch も、
+
+try {
+  ...
+} catch (error) {
+  if (abort.signal.aborted) {
+    return;
+  }
+
+  log("refresh error", error);
+}
+
+とします。
+
+close による abort を "refresh error" として記録しないことが望ましいです。
+
+一方、通常運用中の TURN refresh timeout / 4xx / network error は今までどおり log して次回 refresh を継続します。
+
+つまり今回変更してはいけない既存 semantics は、
+
+一時的な REFRESH failure
+    ↓
+allocation refresh loop 自体は継続
+
+です。
+
+4. cancelable() 自体は変更しない
+
+packages/ice/src/helper.ts の cancelable() を汎用キャンセル Promise に作り替える必要はありません。
+
+既に consent freshness が、
+
+Cancelable
+   +
+AbortController
+
+という構成を採用しています。TURN refresh も同じ lifecycle pattern に寄せる方が影響範囲が小さく、安全です。
+
+5. Regression test を追加する
+
+新規ファイルとして、
+
+packages/ice/tests/ice/turn-protocol-lifecycle.test.ts
+
+程度に分離するのを推奨します。既存の turn-protocol-isolation.test.ts には既に in-memory Transport のパターンがあるため、その方式を再利用できます。
+
+最低限、次の3ケースをカバーします。
+
+Case A — refresh sleep 中に close
+
+ALLOCATE success
+↓
+refresh timer starts
+↓
+TurnProtocol.close()
+↓
+refresh timer is cancelled immediately
+↓
+REFRESH request must never start
+
+確認事項:
+
+close() 後に refresh transaction が開始されない
+close() 後に REFRESH が送信されない
+pending refresh Timeout が残らない
+
+Issue 投稿者の process.getActiveResourcesInfo() を使った regression test はこの確認に適しています。Vitest 自身の timer と競合する場合は、child process に分離して「即時 exit」を検証すると安定します。
+
+Case B — REFRESH transaction 実行中に close
+
+こちらは今回追加でカバーすべき race です。
+
+refresh timer fires
+↓
+REFRESH Transaction created
+↓
+response deliberately withheld
+↓
+close()
+↓
+AbortSignal
+↓
+Transaction.cancel / clearWait
+
+確認事項:
+
+Object.keys(turn.transactions).length === 0
+
+まで即座に収束すること。
+
+そして retry timer が close 後に残らないこと。
+
+このテストがあることで、Issue の sleep-only fix より堅牢な lifecycle 保証になります。
+
+Case C — 通常 refresh の regression
+
+close されていない場合は、
+
+LIFETIME=N
+↓
+5/6 N で REFRESH
+↓
+response の新しい LIFETIME を採用
+↓
+次の refresh を schedule
+
+という現行動作を維持します。
+
+既存 UDP/TCP/TLS TURN integration test もそのまま通す必要があります。現在 packages/ice/tests/ice/turn.test.ts には3 transport の local TURN 接続テストがあります。
+
+
+---
+
+Acceptance criteria
+
+実装完了条件は次のようにするのがよいです。
+
+1. TurnProtocol.close() 完了後、allocation refresh 用 Timeout が残らない。
+
+
+2. refresh sleep 中に close された場合、REFRESH transaction を開始しない。
+
+
+3. REFRESH transaction 実行中に close された場合、その transaction の retry timer も即座に解除される。
+
+
+4. close 後に REFRESH packet を送信しない。custom Transport が closed=false のままでも refresh lifecycle 側で保証する。
+
+
+5. 通常動作中の periodic REFRESH、および 401/438 nonce retry の挙動を変更しない。
+
+
+6. UDP / TCP / TLS TURN の既存テストがすべて成功する。
+
+
+7. close による Abort を "refresh error" として記録しない。
+
+
+8. public API の破壊的変更を行わない。requestWithRetry に追加する引数は optional とする。
+
+
+9. 新規 runtime dependency は追加しない。
+
+
+
+検証コマンドは少なくとも、
+
+npm test --workspace packages/ice
+npm run type --workspace packages/ice
+npm run build --workspace packages/ice
+
+まで通すのが妥当です。
+
+変更対象
+
+必須なのはほぼこの2箇所です。
+
+packages/ice/src/turn/protocol.ts
+packages/ice/tests/ice/turn-protocol-lifecycle.test.ts   # new
+
+リリースまで含める場合は changelog.md に #685 を追加します。現在 werift=0.24.4, werift-ice=0.2.3 なので、通常の patch release 方針なら次回リリース対象になります。
+
+総評としては Issue #685 は採用して修正すべきです。 ただし投稿された最小 diff をそのまま入れるより、既に werift の Transaction が持っている AbortSignal 対応を refresh request にも伝播させ、「sleep 中」と「REFRESH transaction 中」の両方を close() で完全に停止するところまでを #685 の完了条件にするのが適切です。

--- a/TICKET-ticket-4485a305-442a-431b-8e8a-dd18309f62fe.md
+++ b/TICKET-ticket-4485a305-442a-431b-8e8a-dd18309f62fe.md
@@ -1,363 +1,165 @@
-Issue #685 は妥当です。2026年9月4日時点の develop HEAD 0ea9579c273607e8c9c59ca3659cdd79aeff6ad3 にも問題がそのまま残っています。Issue が指摘している「TurnProtocol.close() 後も TURN allocation refresh の timer が生存し、Node.js プロセス終了を妨げる」という主問題はコード上明確に再現します。
+# fix(ice): cancel TURN allocation refresh lifecycle on `TurnProtocol.close()` (#685)
 
-ただし、Issue の説明には1点だけ補足があります。標準の UDP/TCP/TLS transport では、close 後に実際の REFRESH packet が wire に出る可能性は通常ありません。一方で、内部的には REFRESH transaction が開始されてしまうので、問題自体はむしろ Issue の説明より少し広いです。
+## 1. タスクの目的と背景
 
-原因
+TURN allocation の確立後に `TurnProtocol.close()` を呼び出しても、allocation refresh 用のタイマーと、その後に開始される STUN transaction の再送待ちが停止せず、Node.js プロセス終了やリソース解放を遅延させる問題を修正する。
 
-現在の refresh loop は概ね以下の構造です。
+### コードベース調査結果
 
-let run = true;
+- `packages/ice/src/ice.ts` の TURN candidate 収集では、TURN server と credentials が設定されていれば `createStunOverTurnClient()` で `TurnProtocol` を生成し、allocation 成功後すぐに `protocols` へ保持する。relay candidate が nominate されたかどうかは refresh 開始条件ではない。
+- `TurnProtocol.connectionMade()` は ALLOCATE 成功後、応答の `LIFETIME` を使って `refresh(exp)` を開始する。
+- 現在の `TurnProtocol.refresh()` は `cancelable()` の `onCancel` で `run = false` にするだけで、`await setTimeout((5 / 6) * exp * 1000)` 自体を中断していない。タイマー満了直後にも `run` を再確認しないため、close とタイマー満了の競合時に REFRESH request を作成し得る。
+- `TurnProtocol.close()` は `refreshHandle.resolve()` の後に transport を close するだけで、refresh の sleep や transaction に AbortSignal を渡していない。
+- `cancelable()`（`packages/ice/src/helper.ts`）は resolve/reject 時にイベントを発火する仕組みであり、executor 内の非同期処理や既存 timer をキャンセルする汎用機構ではない。今回、`cancelable()` 自体を変更する必要はない。
+- 通常の UDP/TCP/TLS transport は close 後に `closed` が true になり、`TurnProtocol.send()` は送信をスキップする。そのため標準 transport では wire 上の REFRESH が出ない場合があるが、refresh transaction の生成と再送 timer は残り得る。`closed: false` の custom transport では close 後の REFRESH 送信まで再現する。
+- `Transaction`（`packages/ice/src/stun/transaction.ts`）は `TransactionRequestOptions.signal` を既に受け付け、abort 時に `clearTimeout()`、transaction の終了、`transactions` からの削除を行う。ICE consent freshness でも同じ AbortController パターンが使われている。
 
-onCancel.once(() => {
-  run = false;
-});
+現状の default STUN retry は `RETRY_RTO=50ms`、`RETRY_MAX=6` で、closed transport でも最大 `50 + 100 + 200 + 400 + 800 + 1600 + 3200 = 6350ms` の待ちが発生し得る。例えば lifetime=600 秒の場合、close 後も refresh sleep 約500秒と retry 待ち最大約6.35秒が残る可能性がある。
 
-while (run) {
-  await setTimeout((5 / 6) * exp * 1000);
+## 2. 実装すべき具体的な機能や変更内容
 
-  // run を再確認しない
-  const request = new Message(methods.REFRESH, classes.REQUEST);
-  await this.requestWithRetry(request, this.server);
-}
+### 2.1 `TurnProtocol.refresh()` の sleep を Abort 可能にする
 
-TurnProtocol.close() が行っているのは、
+対象: `packages/ice/src/turn/protocol.ts` の `refresh` メソッド。
 
-this.refreshHandle?.resolve?.();
-await this.transport.close();
+- `refresh(exp)` の 1 lifecycle ごとに `AbortController` を1つ生成する。
+- `onCancel.once()` から同 controller を abort し、`TurnProtocol.close()` の既存の `refreshHandle.resolve()` を refresh lifecycle の停止に接続する。
+- `timers/promises` の `setTimeout` に同じ signal を渡す。
 
-だけです。refreshHandle.resolve() → onCancel によって run=false にはなりますが、既に実行中の timers/promises.setTimeout() は cancel されません。しかも timer が満了した直後に run を再評価せず、そのまま REFRESH transaction に入ります。
+  ```ts
+  const abort = new AbortController();
 
-cancelable() 自体も executor を停止するものではなく、resolve/reject 時に onCancel event を発火するだけなので、現在の使い方では timeout を中断できません。
+  onCancel.once(() => {
+    abort.abort();
+  });
 
-この timer は TURN candidate が nominate されたかどうかにも依存しません。TURN server と credentials が設定されて allocation が成功すると createStunOverTurnClient() で protocol が生成されて protocols に保持され、allocation 成功時点で refresh が開始されます。Connection.close() は nominated pair に限定せず保持中の全 protocol を close します。
+  await setTimeout(delay, undefined, { signal: abort.signal });
+  ```
 
-したがって Issue の
+- timeout 復帰直後に `abort.signal.aborted` を再確認し、close と timeout 満了が競合しても REFRESH request を作成しない。
+- timer の例外は catch-all で握りつぶさない。abort に起因する終了だけを正常終了として扱い、それ以外は再 throw する。
+- `{ ref: false }` の追加だけでは不十分であり、post-close の refresh 処理自体を停止する今回の要件を満たさないため使用しない。
 
-> TURN configured + allocation succeeded → relay candidate が使われなくても発生
+### 2.2 REFRESH transaction まで同じ AbortSignal を伝播する
 
+対象: `packages/ice/src/turn/protocol.ts` の `requestWithRetry` と `refresh` の呼び出し。
 
+- `requestWithRetry(request, addr, signal?: AbortSignal)` のように optional な第3引数を追加する。既存 callsite と public API の互換性を維持する。
+- `requestWithRetry()` 内の最初の `this.request()` に、既存の `request()` の options-object 形式で同じ signal を渡す。
+- 401/438 の nonce retry で実行する2回目の `this.request()` にも、同一 signal を必ず渡す。
 
-という影響範囲も正しいです。
+  ```ts
+  await this.request(request, addr, undefined, { signal });
+  // nonce retry も同じ signal
+  await this.request(request, this.server, undefined, { signal });
+  ```
 
-追加で判明した問題
+- `refresh()` から `requestWithRetry(request, this.server, abort.signal)` を呼ぶ。
+- timeout 後に REFRESH transaction が既に開始されている状態で close された場合も、`Transaction` の既存 abort path によって待機中の retry timer を解除し、transaction を終了させる。
+- `request()` の既存 positional/options 引数、`TransactionRequestOptions`、`Transaction` の一般的な semantics は変更しない。
 
-Issue の再現 transport は close() 後も closed: false のため、本当に "REFRESH sent" まで到達します。
+### 2.3 refresh loop の終了と通常エラーを区別する
 
-しかし werift の標準 transport は、
+- refresh の sleep 中に発生した abort、および REFRESH request 中に発生した abortは、close による正常終了としてそのまま loop から return する。
+- abort 以外の timer/request エラーは従来どおり診断可能な形で扱う。
+- 通常運用中の REFRESH timeout、ネットワークエラー、401/438 以外の transaction failure は、現在の `log("refresh error", error)` と同じく記録したうえで、次回 refresh をスケジュールする semantics を維持する。
+- response の `LIFETIME` を次回 refresh の `exp` に採用する既存動作を維持する。
 
-UdpTransport.close() → closed = true
+### 2.4 `cancelable()` と transport の責務は変更しない
 
-StreamTransport.close() → closed = true
+- `packages/ice/src/helper.ts` の `cancelable()` を汎用キャンセル Promise に作り替えない。
+- transport の `closed` 判定や `send()` の挙動を今回の主修正手段にしない。refresh lifecycle 側の AbortSignal で custom transport に対しても close 後の REFRESH 開始・送信を防止する。
+- 新規 runtime dependency は追加しない。
 
-TurnProtocol.send() → transport.closed なら return
+## 3. 技術的な実装アプローチと調査結果
 
+### 制御フロー
 
-となっているため、通常の UDP/TCP/TLS では close 後の REFRESH は wire には出ません。
-
-ただしそこで処理が終了するわけではありません。
-
-timer 満了後には、
-
-refresh()
-  -> requestWithRetry()
-      -> request()
-          -> new Transaction()
-              -> transaction.run()
-                  -> retry()
-
-まで進みます。transport が closed なので packet は送られませんが、Transaction.retry() 自体は response を待つ timer を生成します。現在は RETRY_RTO=50ms, RETRY_MAX=6 なので、
-
-50 + 100 + 200 + 400 + 800 + 1600 + 3200
-= 6350 ms
-
-の追加 wait が発生し得ます。
-
-つまり lifetime=600 秒で allocation 直後に close した最悪ケースでは、
-
-refresh sleep        約 500.00 秒
-STUN retry timers    約   6.35 秒
---------------------------------
-                      約 506.35 秒
-
-プロセスに timer が残る可能性があります。
-
-短命な CLI / test process / serverless worker では終了遅延になりますし、長寿命サーバーでも短時間に多数の PeerConnection を生成・破棄すると、閉じた TurnProtocol が timer closure から最大数百秒保持されるため、一時的なメモリ保持量増加につながります。
-
-そのため修正優先度は比較的高いと考えます。
-
-
----
-
-詳細化した実装タスク
-
-Task title
-
-fix(ice): cancel TURN allocation refresh lifecycle on TurnProtocol.close() (#685)
-
-1. Refresh の sleep を Abort 可能にする
-
-対象:
-
-packages/ice/src/turn/protocol.ts
-
-refresh lifecycle ごとに AbortController を1個生成します。
-
-const abort = new AbortController();
-
-onCancel.once(() => {
-  abort.abort();
-});
-
-そして、
-
-await setTimeout(delay);
-
-を、
-
-await setTimeout(delay, undefined, {
-  signal: abort.signal,
-});
-
-へ変更します。
-
-ただし Issue に掲載されている、
-
-catch (error) {
-  return;
-}
-
-という catch-all より、
-
-catch (error) {
-  if (abort.signal.aborted) {
-    return;
-  }
-  throw error;
-}
-
-とした方が安全です。
-
-さらに timeout 正常満了と close が競合する境界を明確にするため、
-
-if (abort.signal.aborted) {
-  return;
-}
-
-を timeout 復帰直後にも入れます。
-
-{ ref: false } だけを使用する修正は不可です。process exit は可能になりますが、post-close refresh 処理そのものは残るためです。
-
-2. 同じ AbortSignal を REFRESH transaction にも伝播させる
-
-ここは Issue 提案より一段強化することを推奨します。
-
-Issue の diff は「refresh sleep 中に close」されたケースは直しますが、
-
-timeout fires
- ↓
-REFRESH transaction starts
- ↓
-close()
-
-というタイミングでは、既に Transaction 内の retry timer が動いているため cancel できません。
-
-幸い TransactionRequestOptions と Transaction はすでに AbortSignal を正式にサポートしており、ICE consent lifecycle でも同じ仕組みが使われています。新しいキャンセル機構を作る必要はありません。
-
-requestWithRetry() を例えば、
-
-async requestWithRetry(
-  request: Message,
-  addr: Address,
-  signal?: AbortSignal,
-)
-
-へ後方互換で拡張します。
-
-内部の両方の request()、
-
-最初の request
-401 / 438 後の retry request
-
-に必ず同じ signal を渡します。
-
-概念的には、
-
-await this.request(request, addr, undefined, {
-  signal,
-});
-
-および nonce retry でも、
-
-await this.request(request, this.server, undefined, {
-  signal,
-});
-
-とします。
-
-これにより close が REFRESH transaction 実行中に発生しても、Transaction の既存 abort path が clearTimeout() を行い、待機中の retry timer を即座に除去できます。
-
-3. Refresh loop の abort を正常終了として扱う
-
-REFRESH request の catch も、
-
-try {
-  ...
-} catch (error) {
-  if (abort.signal.aborted) {
-    return;
-  }
-
-  log("refresh error", error);
-}
-
-とします。
-
-close による abort を "refresh error" として記録しないことが望ましいです。
-
-一方、通常運用中の TURN refresh timeout / 4xx / network error は今までどおり log して次回 refresh を継続します。
-
-つまり今回変更してはいけない既存 semantics は、
-
-一時的な REFRESH failure
-    ↓
-allocation refresh loop 自体は継続
-
-です。
-
-4. cancelable() 自体は変更しない
-
-packages/ice/src/helper.ts の cancelable() を汎用キャンセル Promise に作り替える必要はありません。
-
-既に consent freshness が、
-
-Cancelable
-   +
-AbortController
-
-という構成を採用しています。TURN refresh も同じ lifecycle pattern に寄せる方が影響範囲が小さく、安全です。
-
-5. Regression test を追加する
-
-新規ファイルとして、
-
-packages/ice/tests/ice/turn-protocol-lifecycle.test.ts
-
-程度に分離するのを推奨します。既存の turn-protocol-isolation.test.ts には既に in-memory Transport のパターンがあるため、その方式を再利用できます。
-
-最低限、次の3ケースをカバーします。
-
-Case A — refresh sleep 中に close
-
+```text
 ALLOCATE success
-↓
-refresh timer starts
-↓
+  -> TurnProtocol.connectionMade()
+  -> refresh(exp)
+  -> timer sleep (5/6 * lifetime)
+  -> requestWithRetry(REFRESH, server, refreshAbort.signal)
+  -> Transaction(signal)
+
 TurnProtocol.close()
-↓
-refresh timer is cancelled immediately
-↓
-REFRESH request must never start
+  -> refreshHandle.resolve()
+  -> onCancel が AbortController.abort()
+  -> sleep timer または Transaction の wait timer を解除
+  -> refresh loop 終了
+  -> transport.close()
+```
 
-確認事項:
+### 実装上の要点
 
-close() 後に refresh transaction が開始されない
-close() 後に REFRESH が送信されない
-pending refresh Timeout が残らない
+1. `timers/promises.setTimeout` の `AbortSignal` 対応を利用し、refresh の長時間 sleep を明示的にキャンセルする。
+2. timeout 復帰後の signal check を request 作成前に置き、close が timer 満了と同時に発生した境界でも post-close REFRESH を開始しない。
+3. `requestWithRetry` は optional signal を初回 request と 401/438 nonce retry の両方へ転送する。`Transaction.run()` は abort を検知すると `failWithTimeout()`、`clearWait()`、listener cleanup を行うため、新しい transaction cancellation 機構は不要である。
+4. close 由来の AbortError/TransactionTimeout を refresh error としてログ出力しない。ただし abort 以外のエラーを広く握りつぶさない。
+5. close 後の `turn.transactions` が空になることと、retry timer が追加で残らないことをテストで確認する。
 
-Issue 投稿者の process.getActiveResourcesInfo() を使った regression test はこの確認に適しています。Vitest 自身の timer と競合する場合は、child process に分離して「即時 exit」を検証すると安定します。
+### テスト実装方針
 
-Case B — REFRESH transaction 実行中に close
+新規ファイル `packages/ice/tests/ice/turn-protocol-lifecycle.test.ts` に lifecycle 専用テストを分離する。既存の `packages/ice/tests/ice/turn-protocol-isolation.test.ts` にある in-memory `Transport`、TURN protocol の初期化、成功 `Message` の組み立てパターンを再利用する。
 
-こちらは今回追加でカバーすべき race です。
+Arrange の共通 setup（mock transport、TURN protocol、成功 response、送信記録、refresh 起動用の helper）は同一テストファイル内の utility に集約する。Act / Assert の操作意図・検証点にはリポジトリ規約どおり日本語コメントを付ける。
 
-refresh timer fires
-↓
-REFRESH Transaction created
-↓
-response deliberately withheld
-↓
-close()
-↓
-AbortSignal
-↓
-Transaction.cancel / clearWait
+#### Case A: refresh sleep 中の close
 
-確認事項:
+- `closed: false` の custom mock transportを使い、refresh delay を短くした TURN protocol を Arrange する。
+- ALLOCATE success 相当で refresh lifecycle を起動し、fake timers で timer が登録された状態にする。
+- Act で `await turn.close()` を実行し、その後に refresh delay まで timer を進める。
+- Assert で、`requestWithRetry` が REFRESH について呼ばれていないこと、REFRESH packet が送信されていないこと、refresh timer が残っていないことを確認する。
+- `vi.useFakeTimers()` と `vi.advanceTimersByTimeAsync()` を基本とする。Vitest の timer と `timers/promises` の相互作用、または `process.getActiveResourcesInfo()` のノイズで不安定になる場合は、最小の child process に分離して close 後に即時終了できることを確認する。
 
-Object.keys(turn.transactions).length === 0
+#### Case B: REFRESH transaction 実行中の close
 
-まで即座に収束すること。
+- 応答を返さない in-memory transport を Arrange し、refresh timer を満了させて実際の REFRESH `Transaction` を開始する。
+- 初回 REFRESH 送信後、response を意図的に withheld にして retry wait timer が存在する状態にする。
+- Act で `await turn.close()` を実行する。
+- Assert で `Object.keys(turn.transactions).length === 0` に収束すること、close 後に REFRESH の再送が発生しないこと、retry timer が残っていないことを確認する。
+- custom transport の `closed` を false のままにして、transport 側の no-op に依存せず lifecycle の abort だけで停止できることを検証する。
 
-そして retry timer が close 後に残らないこと。
+#### Case C: 通常 refresh と nonce retry の regression
 
-このテストがあることで、Issue の sleep-only fix より堅牢な lifecycle 保証になります。
+- close していない protocol で、最初の `LIFETIME=N` に対して `5/6 * N` 経過時に REFRESH が送られることを確認する。
+- REFRESH response の新しい `LIFETIME` が次回 `exp` に反映され、次の refresh が新しい lifetime に基づいて schedule されることを確認する。
+- `requestWithRetry` に渡された signal が、初回 request と 401/438 nonce retry の両方の options に同一 signal として伝播することを確認する。
+- 通常の request failure はログ記録後も refresh loop を継続し、close 由来の abort だけは refresh error として記録されないことを確認する。
 
-Case C — 通常 refresh の regression
+既存の `packages/ice/tests/ice/turn.test.ts` にある local TURN server の UDP/TCP/TLS 接続テストは変更せず、修正後もすべて通過させる。必要に応じて lifecycle test では実ネットワークを使わず、transaction と送信記録を deterministic に制御する。
 
-close されていない場合は、
+## 4. 考慮すべき制約や注意点
 
-LIFETIME=N
-↓
-5/6 N で REFRESH
-↓
-response の新しい LIFETIME を採用
-↓
-次の refresh を schedule
+- Node.js 対象は Unix 系で、package の engines は Node `>=18`。`timers/promises.setTimeout` の signal option を使うため、既存の TypeScript target/module 設定と互換な書き方にする。
+- `requestWithRetry` の第3引数は optional とし、既存の ALLOCATE、CreatePermission、ChannelBind、その他の callsite は無変更で動作させる。
+- 401/438 retry では request の transaction ID を再生成し、nonce / realm / integrityKey を更新する既存処理を壊さない。signal だけを両 request に引き継ぐ。
+- close の race では、signal check と request 開始の境界を明示する。少なくとも close 後に新しい REFRESH transaction が開始されないことを保証する。
+- `Transaction` は abort 時に `TransactionTimeout` を返す実装であるため、refresh loop 側では error の型名だけで通常 timeout と close abort を区別せず、refresh lifecycle の `abort.signal.aborted` を判定基準にする。
+- timer 例外・request 例外を無条件に `return` する catch-all は避け、abort 以外の異常を隠さない。
+- `ref: false` のみの対応、`cancelable()` の全面改修、全 transport の変更、process-wide な timer 管理の導入は今回のスコープ外とする。
+- テスト終了時は作成した protocol / transport を必ず close し、fake timers を real timers に戻す。実ネットワークを使う既存 TURN テストは server と connection を `finally` で close する。
+- 基本の変更対象は `packages/ice/src/turn/protocol.ts` と新規 `packages/ice/tests/ice/turn-protocol-lifecycle.test.ts`。release を同一タスクに含める場合のみ `changelog.md` に #685 の patch 修正を追記する。
 
-という現行動作を維持します。
+## 5. 完了条件
 
-既存 UDP/TCP/TLS TURN integration test もそのまま通す必要があります。現在 packages/ice/tests/ice/turn.test.ts には3 transport の local TURN 接続テストがあります。
+### 機能・互換性
 
+- [ ] `TurnProtocol.close()` 完了後に allocation refresh 用の Timeout が残らない。
+- [ ] refresh sleep 中の close では、REFRESH request / transaction が開始されない。
+- [ ] REFRESH transaction 実行中の close では、同 transaction の retry timer と transaction state が即座に解除され、`turn.transactions` が空になる。
+- [ ] `closed: false` の custom transport を使っても、close 後に REFRESH packet が送信されない。
+- [ ] close 由来の Abort は `refresh error` としてログ記録されない。
+- [ ] 通常の periodic REFRESH、response の新しい LIFETIME の採用、401/438 nonce retry、および一時的な REFRESH failure 後の loop 継続が変わらない。
+- [ ] public API の破壊的変更がない。`requestWithRetry` の追加引数は optional である。
+- [ ] 新規 runtime dependency がない。
 
----
+### テスト・検証
 
-Acceptance criteria
-
-実装完了条件は次のようにするのがよいです。
-
-1. TurnProtocol.close() 完了後、allocation refresh 用 Timeout が残らない。
-
-
-2. refresh sleep 中に close された場合、REFRESH transaction を開始しない。
-
-
-3. REFRESH transaction 実行中に close された場合、その transaction の retry timer も即座に解除される。
-
-
-4. close 後に REFRESH packet を送信しない。custom Transport が closed=false のままでも refresh lifecycle 側で保証する。
-
-
-5. 通常動作中の periodic REFRESH、および 401/438 nonce retry の挙動を変更しない。
-
-
-6. UDP / TCP / TLS TURN の既存テストがすべて成功する。
-
-
-7. close による Abort を "refresh error" として記録しない。
-
-
-8. public API の破壊的変更を行わない。requestWithRetry に追加する引数は optional とする。
-
-
-9. 新規 runtime dependency は追加しない。
-
-
-
-検証コマンドは少なくとも、
-
-npm test --workspace packages/ice
-npm run type --workspace packages/ice
-npm run build --workspace packages/ice
-
-まで通すのが妥当です。
-
-変更対象
-
-必須なのはほぼこの2箇所です。
-
-packages/ice/src/turn/protocol.ts
-packages/ice/tests/ice/turn-protocol-lifecycle.test.ts   # new
-
-リリースまで含める場合は changelog.md に #685 を追加します。現在 werift=0.24.4, werift-ice=0.2.3 なので、通常の patch release 方針なら次回リリース対象になります。
-
-総評としては Issue #685 は採用して修正すべきです。 ただし投稿された最小 diff をそのまま入れるより、既に werift の Transaction が持っている AbortSignal 対応を refresh request にも伝播させ、「sleep 中」と「REFRESH transaction 中」の両方を close() で完全に停止するところまでを #685 の完了条件にするのが適切です。
+- [ ] `packages/ice/tests/ice/turn-protocol-lifecycle.test.ts` で Case A〜C をカバーする。
+- [ ] `npm test --workspace packages/ice` が成功する。
+- [ ] `npm run type --workspace packages/ice` が成功する。
+- [ ] `npm run build --workspace packages/ice` が成功する。
+- [ ] `packages/ice/tests/ice/turn.test.ts` の UDP/TCP/TLS local TURN integration test が成功する。
+- [ ] lifecycle test が timer 実装差や Vitest の timer と競合せず、再現性をもって成功する。

--- a/doc/classes/TurnProtocol.md
+++ b/doc/classes/TurnProtocol.md
@@ -290,7 +290,7 @@ readonly \[`string`, `number`\]
 
 ### requestWithRetry()
 
-> **requestWithRetry**(`request`, `addr`): `Promise`\<\[[`Message`](Message.md), readonly \[`string`, `number`\]\]\>
+> **requestWithRetry**(`request`, `addr`, `signal`?): `Promise`\<\[[`Message`](Message.md), readonly \[`string`, `number`\]\]\>
 
 #### Parameters
 
@@ -301,6 +301,10 @@ readonly \[`string`, `number`\]
 ##### addr
 
 readonly \[`string`, `number`\]
+
+##### signal?
+
+`AbortSignal`
 
 #### Returns
 

--- a/packages/ice/doc/classes/TurnProtocol.md
+++ b/packages/ice/doc/classes/TurnProtocol.md
@@ -290,7 +290,7 @@ readonly \[`string`, `number`\]
 
 ### requestWithRetry()
 
-> **requestWithRetry**(`request`, `addr`): `Promise`\<\[[`Message`](Message.md), readonly \[`string`, `number`\]\]\>
+> **requestWithRetry**(`request`, `addr`, `signal`?): `Promise`\<\[[`Message`](Message.md), readonly \[`string`, `number`\]\]\>
 
 #### Parameters
 
@@ -301,6 +301,10 @@ readonly \[`string`, `number`\]
 ##### addr
 
 readonly \[`string`, `number`\]
+
+##### signal?
+
+`AbortSignal`
 
 #### Returns
 

--- a/packages/ice/src/turn/protocol.ts
+++ b/packages/ice/src/turn/protocol.ts
@@ -327,25 +327,43 @@ export class TurnProtocol implements Protocol {
 
   private refresh = (exp: number) => {
     this.refreshHandle = cancelable<void>(async (_, __, onCancel) => {
-      let run = true;
+      const abort = new AbortController();
       onCancel.once(() => {
-        run = false;
+        abort.abort();
       });
 
-      while (run) {
+      while (!abort.signal.aborted) {
         // refresh before expire
         const delay = (5 / 6) * exp * 1000;
         log("refresh delay", delay, { exp });
-        await setTimeout(delay);
+        try {
+          await setTimeout(delay, undefined, { signal: abort.signal });
+        } catch (error) {
+          if (abort.signal.aborted) {
+            return;
+          }
+          throw error;
+        }
+
+        if (abort.signal.aborted) {
+          return;
+        }
 
         const request = new Message(methods.REFRESH, classes.REQUEST);
         request.setAttribute("LIFETIME", exp);
 
         try {
-          const [message] = await this.requestWithRetry(request, this.server);
+          const [message] = await this.requestWithRetry(
+            request,
+            this.server,
+            abort.signal,
+          );
           exp = message.getAttributeValue("LIFETIME");
           log("refresh", { exp });
         } catch (error) {
+          if (abort.signal.aborted) {
+            return;
+          }
           log("refresh error", error);
         }
       }
@@ -395,10 +413,13 @@ export class TurnProtocol implements Protocol {
   async requestWithRetry(
     request: Message,
     addr: Address,
+    signal?: AbortSignal,
   ): Promise<[Message, Address]> {
     let message: Message, address: Address;
     try {
-      [message, address] = await this.request(request, addr);
+      [message, address] = await this.request(request, addr, undefined, {
+        signal,
+      });
     } catch (error) {
       if (error instanceof TransactionFailed == false) {
         log("requestWithRetry error", error);
@@ -429,7 +450,12 @@ export class TurnProtocol implements Protocol {
         );
 
         request.transactionId = randomTransactionId();
-        [message, address] = await this.request(request, this.server);
+        [message, address] = await this.request(
+          request,
+          this.server,
+          undefined,
+          { signal },
+        );
       } else {
         throw error;
       }

--- a/packages/ice/tests/ice/turn-protocol-lifecycle.test.ts
+++ b/packages/ice/tests/ice/turn-protocol-lifecycle.test.ts
@@ -1,0 +1,193 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("timers/promises", () => ({
+  setTimeout: (
+    delay: number,
+    value?: unknown,
+    options?: { signal?: AbortSignal },
+  ) =>
+    new Promise((resolve, reject) => {
+      const timer = globalThis.setTimeout(() => {
+        options?.signal?.removeEventListener("abort", onAbort);
+        resolve(value);
+      }, delay);
+      const onAbort = () => {
+        globalThis.clearTimeout(timer);
+        reject(new DOMException("The operation was aborted", "AbortError"));
+      };
+      options?.signal?.addEventListener("abort", onAbort, { once: true });
+    }),
+}));
+
+import type { Address, Transport } from "../../../common/src";
+import { TransactionFailed } from "../../src/exceptions";
+import { classes, methods } from "../../src/stun/const";
+import { Message, parseMessage } from "../../src/stun/message";
+import { TurnProtocol } from "../../src/turn/protocol";
+import type { TransactionRequestOptions } from "../../src/types/model";
+
+interface TurnLifecycleHarness {
+  sentMethods: number[];
+  transport: Transport;
+  turn: TurnProtocol;
+}
+
+function createTurnLifecycleHarness(): TurnLifecycleHarness {
+  const sentMethods: number[] = [];
+  const transport: Transport = {
+    type: "udp",
+    closed: false,
+    onData: () => {},
+    address: { address: "127.0.0.1", port: 0, family: "IPv4" },
+    send: async (data) => {
+      sentMethods.push(parseMessage(data)!.messageMethod);
+    },
+    close: async () => {},
+  };
+  const turn = new TurnProtocol(
+    ["127.0.0.1", 3478],
+    "user",
+    "pass",
+    600,
+    transport,
+  );
+
+  return { sentMethods, transport, turn };
+}
+
+function startRefresh(turn: TurnProtocol, lifetime: number) {
+  (turn as unknown as { refresh: (exp: number) => void }).refresh(lifetime);
+}
+
+function refreshResponse(lifetime: number) {
+  return new Message(methods.REFRESH, classes.RESPONSE).setAttribute(
+    "LIFETIME",
+    lifetime,
+  );
+}
+
+describe("TurnProtocol refresh lifecycle", () => {
+  const turns: TurnProtocol[] = [];
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(async () => {
+    await Promise.all(turns.splice(0).map((turn) => turn.close()));
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  test("refresh sleep 中の close は REFRESH を開始しない", async () => {
+    // Arrange: transport が close 後も送信可能な状態を維持する protocol を作る
+    const { sentMethods, transport, turn } = createTurnLifecycleHarness();
+    turns.push(turn);
+    const requestWithRetry = vi.spyOn(turn, "requestWithRetry");
+    startRefresh(turn, 0.12);
+    expect(vi.getTimerCount()).toBe(1);
+
+    // Act: refresh delay の途中で close し、元の満了時刻より先まで進める
+    await turn.close();
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    // Assert: transport.closed に頼らず request、packet、timer が全て残らない
+    expect(transport.closed).toBe(false);
+    expect(requestWithRetry).not.toHaveBeenCalled();
+    expect(sentMethods).not.toContain(methods.REFRESH);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  test("実行中の REFRESH transaction を close が即座に停止する", async () => {
+    // Arrange: 応答しない transport で refresh transaction を開始する
+    const { sentMethods, transport, turn } = createTurnLifecycleHarness();
+    turns.push(turn);
+    startRefresh(turn, 0.12);
+    await vi.advanceTimersByTimeAsync(100);
+    expect(
+      sentMethods.filter((method) => method === methods.REFRESH),
+    ).toHaveLength(1);
+    expect(Object.keys(turn.transactions)).toHaveLength(1);
+
+    // Act: retry 待機中に close し、その後も十分に時刻を進める
+    await turn.close();
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    // Assert: transaction と retry timer が消え、close 後の再送も発生しない
+    expect(transport.closed).toBe(false);
+    expect(Object.keys(turn.transactions)).toHaveLength(0);
+    expect(
+      sentMethods.filter((method) => method === methods.REFRESH),
+    ).toHaveLength(1);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  test("response の LIFETIME を次回 refresh delay に採用する", async () => {
+    // Arrange: 1 回目の応答で lifetime を 2 倍に更新する
+    const { turn } = createTurnLifecycleHarness();
+    turns.push(turn);
+    const requestWithRetry = vi
+      .spyOn(turn, "requestWithRetry")
+      .mockResolvedValueOnce([refreshResponse(0.24), turn.server])
+      .mockResolvedValue([refreshResponse(0.24), turn.server]);
+    startRefresh(turn, 0.12);
+
+    // Act: 初回 100ms と、更新後の次回 200ms の境界まで進める
+    await vi.advanceTimersByTimeAsync(100);
+    await vi.advanceTimersByTimeAsync(199);
+
+    // Assert: 更新後 lifetime の満了前には 2 回目を開始しない
+    expect(requestWithRetry).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(requestWithRetry).toHaveBeenCalledTimes(2);
+    expect(requestWithRetry.mock.calls[0]?.[2]).toBeInstanceOf(AbortSignal);
+  });
+
+  test("一時的な refresh failure の後も loop を継続する", async () => {
+    // Arrange: 最初の refresh だけ通常エラーで失敗させる
+    const { turn } = createTurnLifecycleHarness();
+    turns.push(turn);
+    const requestWithRetry = vi
+      .spyOn(turn, "requestWithRetry")
+      .mockRejectedValueOnce(new Error("temporary failure"))
+      .mockResolvedValue([refreshResponse(0.12), turn.server]);
+    startRefresh(turn, 0.12);
+
+    // Act: 2 回分の refresh delay を進める
+    await vi.advanceTimersByTimeAsync(200);
+
+    // Assert: 通常エラーでは lifecycle を終了せず次回 request を行う
+    expect(requestWithRetry).toHaveBeenCalledTimes(2);
+  });
+
+  test("nonce retry の両 request に同じ AbortSignal を渡す", async () => {
+    // Arrange: 初回 request は 401、nonce 付き retry は成功するようにする
+    const { turn } = createTurnLifecycleHarness();
+    turns.push(turn);
+    const unauthorized = new Message(methods.REFRESH, classes.ERROR)
+      .setAttribute("ERROR-CODE", [401, "Unauthorized"])
+      .setAttribute("REALM", "test.local")
+      .setAttribute("NONCE", Buffer.from("nonce"));
+    const request = new Message(methods.REFRESH, classes.REQUEST);
+    const signal = new AbortController().signal;
+    const requestSpy = vi
+      .spyOn(turn, "request")
+      .mockRejectedValueOnce(new TransactionFailed(unauthorized, turn.server))
+      .mockResolvedValueOnce([refreshResponse(600), turn.server]);
+
+    // Act: authentication challenge を処理して同じ request を再試行する
+    await turn.requestWithRetry(request, turn.server, signal);
+
+    // Assert: 初回と nonce retry の options に同一 signal が伝播する
+    expect(requestSpy).toHaveBeenCalledTimes(2);
+    const firstOptions = requestSpy.mock.calls[0]?.[3] as
+      | TransactionRequestOptions
+      | undefined;
+    const retryOptions = requestSpy.mock.calls[1]?.[3] as
+      | TransactionRequestOptions
+      | undefined;
+    expect(firstOptions?.signal).toBe(signal);
+    expect(retryOptions?.signal).toBe(signal);
+  });
+});

--- a/packages/ice/tests/ice/turn-protocol-lifecycle.test.ts
+++ b/packages/ice/tests/ice/turn-protocol-lifecycle.test.ts
@@ -1,5 +1,15 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
+const debugState = vi.hoisted(() => {
+  const log = vi.fn();
+  const debug = vi.fn(() => log);
+  return { debug, log };
+});
+
+vi.mock("debug", () => ({
+  default: { debug: debugState.debug },
+}));
+
 vi.mock("timers/promises", () => ({
   setTimeout: (
     delay: number,
@@ -71,6 +81,7 @@ describe("TurnProtocol refresh lifecycle", () => {
 
   beforeEach(() => {
     vi.useFakeTimers();
+    debugState.log.mockClear();
   });
 
   afterEach(async () => {
@@ -121,6 +132,10 @@ describe("TurnProtocol refresh lifecycle", () => {
       sentMethods.filter((method) => method === methods.REFRESH),
     ).toHaveLength(1);
     expect(vi.getTimerCount()).toBe(0);
+    expect(debugState.log).not.toHaveBeenCalledWith(
+      "refresh error",
+      expect.anything(),
+    );
   });
 
   test("response の LIFETIME を次回 refresh delay に採用する", async () => {
@@ -161,33 +176,50 @@ describe("TurnProtocol refresh lifecycle", () => {
     expect(requestWithRetry).toHaveBeenCalledTimes(2);
   });
 
-  test("nonce retry の両 request に同じ AbortSignal を渡す", async () => {
-    // Arrange: 初回 request は 401、nonce 付き retry は成功するようにする
-    const { turn } = createTurnLifecycleHarness();
-    turns.push(turn);
-    const unauthorized = new Message(methods.REFRESH, classes.ERROR)
-      .setAttribute("ERROR-CODE", [401, "Unauthorized"])
-      .setAttribute("REALM", "test.local")
-      .setAttribute("NONCE", Buffer.from("nonce"));
-    const request = new Message(methods.REFRESH, classes.REQUEST);
-    const signal = new AbortController().signal;
-    const requestSpy = vi
-      .spyOn(turn, "request")
-      .mockRejectedValueOnce(new TransactionFailed(unauthorized, turn.server))
-      .mockResolvedValueOnce([refreshResponse(600), turn.server]);
+  test.each([
+    {
+      errorCode: 401,
+      reason: "Unauthorized",
+      initialRealm: undefined,
+      responseRealm: "test.local",
+    },
+    {
+      errorCode: 438,
+      reason: "Stale Nonce",
+      initialRealm: "test.local",
+      responseRealm: "test.local",
+    },
+  ])(
+    "$errorCode nonce retry の両 request に同じ AbortSignal を渡す",
+    async ({ errorCode, reason, initialRealm, responseRealm }) => {
+      // Arrange: 401/438 challenge と nonce 付き retry が成功する protocol を作る
+      const { turn } = createTurnLifecycleHarness();
+      turns.push(turn);
+      turn.realm = initialRealm;
+      const challenge = new Message(methods.REFRESH, classes.ERROR)
+        .setAttribute("ERROR-CODE", [errorCode, reason])
+        .setAttribute("REALM", responseRealm)
+        .setAttribute("NONCE", Buffer.from("nonce"));
+      const request = new Message(methods.REFRESH, classes.REQUEST);
+      const signal = new AbortController().signal;
+      const requestSpy = vi
+        .spyOn(turn, "request")
+        .mockRejectedValueOnce(new TransactionFailed(challenge, turn.server))
+        .mockResolvedValueOnce([refreshResponse(600), turn.server]);
 
-    // Act: authentication challenge を処理して同じ request を再試行する
-    await turn.requestWithRetry(request, turn.server, signal);
+      // Act: authentication challenge を処理して同じ request を再試行する
+      await turn.requestWithRetry(request, turn.server, signal);
 
-    // Assert: 初回と nonce retry の options に同一 signal が伝播する
-    expect(requestSpy).toHaveBeenCalledTimes(2);
-    const firstOptions = requestSpy.mock.calls[0]?.[3] as
-      | TransactionRequestOptions
-      | undefined;
-    const retryOptions = requestSpy.mock.calls[1]?.[3] as
-      | TransactionRequestOptions
-      | undefined;
-    expect(firstOptions?.signal).toBe(signal);
-    expect(retryOptions?.signal).toBe(signal);
-  });
+      // Assert: 初回と nonce retry の options に同一 signal が伝播する
+      expect(requestSpy).toHaveBeenCalledTimes(2);
+      const firstOptions = requestSpy.mock.calls[0]?.[3] as
+        | TransactionRequestOptions
+        | undefined;
+      const retryOptions = requestSpy.mock.calls[1]?.[3] as
+        | TransactionRequestOptions
+        | undefined;
+      expect(firstOptions?.signal).toBe(signal);
+      expect(retryOptions?.signal).toBe(signal);
+    },
+  );
 });


### PR DESCRIPTION
## Summary
- Cancel TURN refresh sleeps and in-flight retry timers when `TurnProtocol` closes.
- Propagate one `AbortSignal` through initial requests and 401/438 nonce retries.
- Add lifecycle coverage and update the generated API docs.

## Tests
- `npm test --workspace packages/ice`
- `npm run type --workspace packages/ice`
- `npm run build --workspace packages/ice`

Fixes #685